### PR TITLE
Update Docker Compose to use EdgeX Foundry Docker Hub Repos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '2'
 services:
   volume:
-    image: dellfuse/docker-edgex-volume
+    image: edgexfoundry/docker-edgex-volume
     container_name: edgex-files
     networks:
       - edgex-network
@@ -14,7 +14,7 @@ services:
       - /consul/data
 
   consul:
-    image: dellfuse/docker-core-consul
+    image: edgexfoundry/docker-core-consul
     ports:
       - "8400:8400"
       - "8500:8500"
@@ -29,7 +29,7 @@ services:
       - volume
 
   config-seed:
-    image: dellfuse/docker-core-config-seed
+    image: edgexfoundry/docker-core-config-seed
     container_name: edgex-config-seed
     hostname: edgex-core-config-seed
     networks:
@@ -41,7 +41,7 @@ services:
       - consul
 
   mongo:
-    image: dellfuse/docker-edgex-mongo
+    image: edgexfoundry/docker-edgex-mongo
     ports:
       - "27017:27017"
     container_name: edgex-mongo
@@ -55,7 +55,7 @@ services:
     command: --smallfiles
 
   mongo-seed:
-    image: dellfuse/docker-edgex-mongo-seed
+    image: edgexfoundry/docker-edgex-mongo-seed
     container_name: edgex-mongo-seed
     hostname: edgex-mongo-seed
     networks:
@@ -67,7 +67,7 @@ services:
       - mongo
 
   logging:
-    image: dellfuse/docker-support-logging
+    image: edgexfoundry/docker-support-logging
     ports:
       - "48061:48061"
     container_name: edgex-support-logging
@@ -84,7 +84,7 @@ services:
       - mongo-seed
 
   notifications:
-    image: dellfuse/docker-support-notifications
+    image: edgexfoundry/docker-support-notifications
     ports:
       - "48060:48060"
     container_name: edgex-support-notifications
@@ -102,7 +102,7 @@ services:
       - logging
 
   metadata:
-    image: dellfuse/docker-core-metadata
+    image: edgexfoundry/docker-core-metadata
     ports:
       - "48081:48081"
     container_name: edgex-core-metadata
@@ -120,7 +120,7 @@ services:
       - logging
 
   data:
-    image: dellfuse/docker-core-data
+    image: edgexfoundry/docker-core-data
     ports:
       - "48080:48080"
       - "5563"
@@ -140,7 +140,7 @@ services:
       - notifications
 
   command:
-    image: dellfuse/docker-core-command
+    image: edgexfoundry/docker-core-command
     ports:
       - "48082:48082"
     container_name: edgex-core-command
@@ -159,7 +159,7 @@ services:
       - metadata
 
   scheduler:
-    image: dellfuse/docker-support-scheduler
+    image: edgexfoundry/docker-support-scheduler
     ports:
       - "48085:48085"
     container_name: edgex-support-scheduler
@@ -179,7 +179,7 @@ services:
       - command
 
   export-client:
-    image: dellfuse/docker-export-client
+    image: edgexfoundry/docker-export-client
     ports:
       - "48071:48071"
     container_name: edgex-export-client
@@ -200,7 +200,7 @@ services:
       - data
 
   export-distro:
-    image: dellfuse/docker-export-distro
+    image: edgexfoundry/docker-export-distro
     ports:
       - "48070:48070"
       - "5566"
@@ -223,7 +223,7 @@ services:
       - export-client
 
   rulesengine:
-    image: dellfuse/docker-support-rulesengine
+    image: edgexfoundry/docker-support-rulesengine
     ports:
       - "48075:48075"
     container_name: edgex-support-rulesengine
@@ -248,7 +248,7 @@ services:
 #################################################################
 
   device-virtual:
-    image: dellfuse/docker-device-virtual
+    image: edgexfoundry/docker-device-virtual
     ports:
       - "49990:49990"
     container_name: edgex-device-virtual

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@
 
 version: '2'
 services:
+
+#################################################################
+# Base config and database services
+#################################################################
   volume:
     image: edgexfoundry/docker-edgex-volume
     container_name: edgex-files
@@ -66,6 +70,9 @@ services:
       - volume
       - mongo
 
+#################################################################
+# Required Supporting Services
+#################################################################
   logging:
     image: edgexfoundry/docker-support-logging
     ports:
@@ -101,6 +108,9 @@ services:
       - mongo-seed
       - logging
 
+#################################################################
+# Core Services
+#################################################################
   metadata:
     image: edgexfoundry/docker-core-metadata
     ports:
@@ -158,6 +168,9 @@ services:
       - logging
       - metadata
 
+#################################################################
+# Additional Supporting Service
+#################################################################
   scheduler:
     image: edgexfoundry/docker-support-scheduler
     ports:
@@ -178,6 +191,9 @@ services:
       - metadata
       - command
 
+#################################################################
+# North Side Services
+#################################################################
   export-client:
     image: edgexfoundry/docker-export-client
     ports:


### PR DESCRIPTION
Update the docker-compose.yml to use containers from the EdgeX Foundry Docker Hub account versus the Dell Fuse Docker Hub account