### PR TITLE
Add script to run services in the correct order

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@ Main Author: Jim White
 Copyright 2016-17, Dell, Inc.
 
 This repos contains scripts, batch files, JSON used in REST calls and other miscellaneous items used by developers buiding EdgeX.
+
+## Running on Linux
+
+For convenience there is run-it.sh script that will start the services
+in order as described [HERE](https://wiki.edgexfoundry.org/display/FA/Get+EdgeX+Foundry+-+Users).

--- a/run-it.sh
+++ b/run-it.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# Copyright 2017 Konrad Zapalowicz <bergo.torino@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Start EdgeX Foundry services in right order, as described:
+# https://wiki.edgexfoundry.org/display/FA/Get+EdgeX+Foundry+-+Users
+
+run_service () {
+	echo "\033[0;32mStarting.. $1\033[0m"
+	docker-compose up -d $1
+}
+
+run_service volume
+sleep 10
+run_service consul
+sleep 65
+run_service config-seed
+run_service mongo
+sleep 12
+run_service mongo-seed
+run_service logging
+sleep 65
+run_service notifications
+sleep 33
+run_service metadata
+sleep 60
+run_service data
+sleep 60
+run_service command
+sleep 60
+run_service scheduler
+sleep 60
+run_service export-client
+sleep 60
+run_service export-distro
+sleep 60
+run_service rulesengine
+sleep 60
+run_service device-virtual


### PR DESCRIPTION
Based on
https://wiki.edgexfoundry.org/display/FA/Get+EdgeX+Foundry+-+Users
script makes sure services are started in the right order and with
enough waiting time for the dependencies to become live.