### PR TITLE
Remove mongo-seed docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,19 +52,6 @@ services:
       - volume
     depends_on:
       - volume
-    command: --smallfiles
-
-  mongo-seed:
-    image: edgexfoundry/docker-edgex-mongo-seed
-    container_name: edgex-mongo-seed
-    hostname: edgex-mongo-seed
-    networks:
-      - edgex-network
-    volumes_from:
-      - volume
-    depends_on:
-      - volume
-      - mongo
 
   logging:
     image: edgexfoundry/docker-support-logging


### PR DESCRIPTION
It is no longer needed after docker-edgex-mongo is executing the init_mongo.js every time it starts.

This change should not be merged until the updated docker-edgex-mongo is pushed to the docker hub.