### PR TITLE
Merged consul and config-seed into one docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,32 +13,22 @@ services:
       - /consul/config
       - /consul/data
 
-  consul:
-    image: edgexfoundry/docker-core-consul
-    ports:
-      - "8400:8400"
-      - "8500:8500"
-      - "8600:8600"
-    container_name: edgex-core-consul
-    hostname: edgex-core-consul
-    networks:
-      - edgex-network
-    volumes_from:
-      - volume
-    depends_on:
-      - volume
-
   config-seed:
     image: edgexfoundry/docker-core-config-seed
+    ports:
+        - "8400:8400"
+        - "8500:8500"
+        - "8600:8600"
     container_name: edgex-config-seed
-    hostname: edgex-core-config-seed
+    hostname: edgex-core-config-seed 
     networks:
-      - edgex-network
+      edgex-network:
+        aliases:
+            - edgex-core-consul
     volumes_from:
       - volume
     depends_on:
       - volume
-      - consul
 
   mongo:
     image: edgexfoundry/docker-edgex-mongo
@@ -65,7 +55,6 @@ services:
       - volume
     depends_on:
       - volume
-      - consul
       - config-seed
       - mongo
 
@@ -81,7 +70,6 @@ services:
       - volume
     depends_on:
       - volume
-      - consul
       - config-seed
       - mongo
       - logging
@@ -98,7 +86,6 @@ services:
       - volume
     depends_on:
       - volume
-      - consul
       - config-seed
       - mongo
       - logging
@@ -116,7 +103,6 @@ services:
       - volume
     depends_on:
       - volume
-      - consul
       - config-seed
       - mongo
       - logging
@@ -134,7 +120,6 @@ services:
       - volume
     depends_on:
       - volume
-      - consul
       - config-seed
       - mongo
       - logging
@@ -152,7 +137,6 @@ services:
       - volume
     depends_on:
       - volume
-      - consul
       - config-seed
       - mongo
       - logging
@@ -171,7 +155,6 @@ services:
       - volume
     depends_on:
       - volume
-      - consul
       - config-seed
       - mongo
       - logging
@@ -192,7 +175,6 @@ services:
       - volume
     depends_on:
       - volume
-      - consul
       - config-seed
       - mongo
       - logging
@@ -213,7 +195,6 @@ services:
       - volume
     depends_on:
       - volume
-      - consul
       - config-seed
       - mongo
       - logging
@@ -237,7 +218,6 @@ services:
       - volume
     depends_on:
       - volume
-      - consul
       - config-seed
       - mongo
       - logging

--- a/run-it.sh
+++ b/run-it.sh
@@ -19,14 +19,12 @@
 # https://wiki.edgexfoundry.org/display/FA/Get+EdgeX+Foundry+-+Users
 
 run_service () {
-	echo "\033[0;32mStarting.. $1\033[0m"
+	echo -e "\033[0;32mStarting.. $1\033[0m"
 	docker-compose up -d $1
 }
 
 run_service volume
 sleep 10
-run_service consul
-sleep 65
 run_service config-seed
 run_service mongo
 sleep 12


### PR DESCRIPTION
To avoid high memory peaks during docker deployment, we have merged consul configuration and config-seed.
Modified docker-compose and run-it removing all consul references since now it is launched from config-seed

This PR requires the PR in core-config-seed