### PR TITLE
Create C:\Users\Public\mongodb\db directory if it doesn't exist.

### DIFF
--- a/startdb-no-auth.bat
+++ b/startdb-no-auth.bat
@@ -1,6 +1,12 @@
-:PUBLIC
-@ECHO PUBLIC PATH
-start "" "C:\Program Files\MongoDB\Server\3.0\bin\mongod.exe" --dbpath "C:\Users\Public\mongodb\db"
+@ECHO off
+SET dbpath="C:\Users\Public\mongodb\db"
+if not exist %dbpath% (
+  echo %dbpath% directory does not exist. Creating...
+  mkdir %dbpath%
+  echo off
+)
+  
+start "" "C:\Program Files\MongoDB\Server\3.6\bin\mongod.exe" --dbpath %dbpath%
 GOTO END
 
 :END


### PR DESCRIPTION
Signed-off-by: Trevor Conn <trevor_conn@dell.com>

MongoDB won't start if the specified directory doesn't exist, so I had to manually create it. I thought it would be helpful to have the script do a check and then create the directory for me.