### PR TITLE
clean_mongo.sh should remove export client entries

### DIFF
--- a/clean_mongo.js
+++ b/clean_mongo.js
@@ -46,3 +46,5 @@ db.auth('notifications','password');
 db.notification.remove({});
 db.subscription.remove({});
 db.transmission.remove({});
+db=db.getSiblingDB('exportclient')
+db.exportConfiguration.remove({});

--- a/init_mongo.js
+++ b/init_mongo.js
@@ -32,6 +32,7 @@ db.serviceMapping.insert( { serviceName: "command", serviceUrl: "http://localhos
 db.serviceMapping.insert( { serviceName: "rules", serviceUrl: "http://localhost:48084/" });
 db.serviceMapping.insert( { serviceName: "notifications", serviceUrl: "http://localhost:48060/" });
 db.serviceMapping.insert( { serviceName: "logging", serviceUrl: "http://localhost:48061/" });
+db.serviceMapping.insert( { serviceName: "exportclient", serviceUrl: "http://localhost:48071/" });
 
 db=db.getSiblingDB('admin')
 db.system.users.remove({});
@@ -123,3 +124,12 @@ db.createCollection("interval");
 db.createCollection("intervalAction");
 db.interval.createIndex({slug: 1}, {unique: true});
 db.intervalAction.createIndex({slug: 1}, {unique: true});
+
+db=db.getSiblingDB('exportclient')
+db.createUser({ user: "exportclient",
+  pwd: "password",
+  roles: [
+    { role: "readWrite", db: "exportclient" }
+  ]
+});
+db.createCollection("exportConfiguration");


### PR DESCRIPTION
#99 

Remove export client entries in clean_mongo.sh . Also remove serviceMapping entries so the `init_mongo.sh`/`clean_mongo.sh` loop is clean.