### PR TITLE
Docker-Compose for Raspberry Pi-3 (arm64)

### DIFF
--- a/compose-files/docker-compose-delhi-0.7.1-arm64.yml
+++ b/compose-files/docker-compose-delhi-0.7.1-arm64.yml
@@ -1,5 +1,4 @@
 # /*******************************************************************************
-#  * Copyright 2018 Dell Inc.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -132,8 +131,6 @@ services:
       - consul-data:/consul/data
     depends_on:
       - edgex-support-notifications
-
-# Perhaps the error is network related, it could work when the network is fixed
   edgex-support-scheduler:
     image: edgexfoundry/docker-support-scheduler-go-arm64:0.7.1
     ports:

--- a/compose-files/docker-compose-delhi-0.7.1-arm64.yml
+++ b/compose-files/docker-compose-delhi-0.7.1-arm64.yml
@@ -1,0 +1,202 @@
+# /*******************************************************************************
+#  * Copyright 2018 Dell Inc.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License. You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software distributed under the License
+#  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  * or implied. See the License for the specific language governing permissions and limitations under
+#  * the License.
+#  *
+#  * @author: Odysseas Lamtzidis
+#  * EdgeX Foundry, Delhi, version 0.7.1
+#  * added: Apr 26, 2019
+#  *******************************************************************************/
+
+version: '2.1'
+volumes:
+  db-data:
+  log-data:
+  consul-config:
+  consul-data:
+
+services:
+
+  volume:
+    image: edgexfoundry/docker-edgex-volume-arm64:0.8.0
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+      
+  edgex-core-consul:
+    image: consul:1.4.0
+    ports:
+      - "8400:8400"
+      - "8500:8500"
+      - "8600:8600"
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - volume  
+
+  edgex-core-config-seed:
+    image: edgexfoundry/docker-core-config-seed-go-arm64:0.7.1
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - volume
+      - edgex-core-consul 
+
+  edgex-mongo:
+    image: edgexfoundry/docker-edgex-mongo-arm64:0.8.0
+    ports:
+      - "27017:27017"
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - volume
+
+  edgex-support-logging:
+    image: edgexfoundry/docker-support-logging-go-arm64:0.7.1
+    ports:
+      - "48061:48061"
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - edgex-core-config-seed
+      - edgex-mongo
+      - volume
+
+  edgex-support-notifications:
+    image: edgexfoundry/docker-support-notifications-go-arm64:0.7.1
+    ports:
+      - "48060:48060" 
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - edgex-support-logging
+
+  edgex-core-metadata:
+    image: edgexfoundry/docker-core-metadata-go-arm64:0.7.1
+    ports:
+      - "48081:48081"
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - edgex-support-logging
+
+  edgex-core-data:
+    image: edgexfoundry/docker-core-data-go-arm64:0.7.1
+    ports:
+      - "48080:48080"
+      - "5563:5563"
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - edgex-support-logging
+
+  edgex-core-command:
+    image: edgexfoundry/docker-core-command-go-arm64:0.7.1
+    ports:
+      - "48082:48082"
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - edgex-support-notifications
+
+# Perhaps the error is network related, it could work when the network is fixed
+  edgex-support-scheduler:
+    image: edgexfoundry/docker-support-scheduler-go-arm64:0.7.1
+    ports:
+      - "48085:48085"
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - edgex-core-metadata
+
+  edgex-export-client:
+    image: edgexfoundry/docker-export-client-go-arm64:0.7.1
+    ports:
+      - "48071:48071"
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - edgex-core-data
+    environment:
+      - EXPORT_CLIENT_MONGO_URL=edgex-mongo
+      - EXPORT_CLIENT_DISTRO_HOST=export-distro
+      - EXPORT_CLIENT_CONSUL_HOST=edgex-config-seed
+
+  edgex-export-distro:
+    image: edgexfoundry/docker-export-distro-go-arm64:0.7.1
+    ports:
+      - "48070:48070"
+      - "5566:5566"
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - edgex-export-client
+    environment:
+      - EXPORT_DISTRO_CLIENT_HOST=export-client
+      - EXPORT_DISTRO_DATA_HOST=edgex-core-data
+      - EXPORT_DISTRO_CONSUL_HOST=edgex-config-seed
+      - EXPORT_DISTRO_MQTTS_CERT_FILE=none
+      - EXPORT_DISTRO_MQTTS_KEY_FILE=none
+
+#################################################################
+# Device Services
+#################################################################
+
+  device-random:
+    image: edgexfoundry/docker-device-random-go-arm64:0.7.1
+    ports:
+      - "49988:49988"
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - edgex-core-data
+      - edgex-core-command
+#
+
+...


### PR DESCRIPTION
This compose-file was built to be used on Raspberry-pi 3 with BalenaOS (64bit BETA version). It can be used on any device with the same architecture and a linux based OS. It has a balance between functionality and RAM/CPU load. Random-Int device service is loaded by default for testing purposes. Not stable enough for production env (due to mongo-DB excess RAM usage).

Signed-off-by: Odysseas Lamtzidis <odyslam@gmail.com>