### PR TITLE
issue_108 interval and intervalAction wrong index in Scheduler collec…

### DIFF
--- a/init_mongo.js
+++ b/init_mongo.js
@@ -122,8 +122,8 @@ db.createUser({ user: "scheduler",
 });
 db.createCollection("interval");
 db.createCollection("intervalAction");
-db.interval.createIndex({slug: 1}, {unique: true});
-db.intervalAction.createIndex({slug: 1}, {unique: true});
+db.interval.createIndex({name: 1}, {unique: true});
+db.intervalAction.createIndex({name: 1}, {unique: true});
 
 db=db.getSiblingDB('exportclient')
 db.createUser({ user: "exportclient",


### PR DESCRIPTION
…tion  Changed the default index for these two collection to use name

Changing init_mongo.js entries for the Scheduler collections interval and intervalAction.
The indexes are incorrectly named "slug" and they should reference the "name" field.  

Signed-off-by: xmlviking <ecotter@gmail.com>