### PR TITLE
issue_113 adding edgex-device-snmp docker compose entries  Docker com…

### DIFF
--- a/compose-files/docker-compose.yml
+++ b/compose-files/docker-compose.yml
@@ -339,22 +339,25 @@ services:
 #       - data
 #       - command
 
-#   device-snmp:
-#     image: nexus3.edgexfoundry.org:10004/docker-device-snmp:0.6.0
-#     ports:
-#       - "49989:49989"
-#     container_name: edgex-device-snmp
-#     hostname: edgex-device-snmp
-#     networks:
-#       - edgex-network
+#  device-snmp-go:
+#    image: nexus3.edgexfoundry.org:10004/docker-device-snmp-go:1.0.0
+#    ports:
+#      - "49993:49993"
+#      - "161:161"
+#    container_name: edgex-device-snmp
+#    hostname: edgex-device-snmp
+#    networks:
+#      edgex-network:
+#        aliases:
+#          - edgex-device-snmp
 #    volumes:
 #      - db-data:/data/db
 #      - log-data:/edgex/logs
 #      - consul-config:/consul/config
 #      - consul-data:/consul/data
-#     depends_on:
-#       - data
-#       - command
+#    depends_on:
+#      - data
+#      - command
 
 #   device-fischertechnik:
 #     image: nexus3.edgexfoundry.org:10004/docker-device-fischertechnik:0.6.0


### PR DESCRIPTION
…pose entries are made in commented out section in preparation for the release. The docker-compose reflects the build in nexus in the edgexfoundry repository build area.

Added the edgex-device-snmp-go to the developer scripts docker-compose.yml.  
NOTE: The image location is pointing to the nexus3 area for our daily builds.  When a formal release is completed for the service we can change it to the docker hub location 

A user would be required to uncomment out this section for it to work.   The idea is that upon release the docker-compose.yml would be copied with this change in it.  Upon release the edgex-go services would all have there versions updated from the existing 0.7.1 to the new 1.0.0.  This has been tested with the nexus3 latest versions for the edgex services.   



Signed-off-by: xmlviking <ecotter@gmail.com>