### PR TITLE
Updating docker-compose for edinburgh with device-snmp-go

### DIFF
--- a/compose-files/docker-compose-edinburgh-1.0.0.yml
+++ b/compose-files/docker-compose-edinburgh-1.0.0.yml
@@ -337,14 +337,17 @@ services:
 #       - data
 #       - command
 
-#   device-snmp:
-#     image: nexus3.edgexfoundry.org:10004/docker-device-snmp:0.6.0
-#     ports:
-#       - "49989:49989"
-#     container_name: edgex-device-snmp
-#     hostname: edgex-device-snmp
-#     networks:
-#       - edgex-network
+#  device-snmp-go:
+#    image: nexus3.edgexfoundry.org:10004/docker-device-snmp-go:1.0.0
+#    ports:
+#      - "49993:49993"
+#      - "161:161"
+#    container_name: edgex-device-snmp
+#    hostname: edgex-device-snmp
+#    networks:
+#      edgex-network:
+#        aliases:
+#          - edgex-device-snmp
 #    volumes:
 #      - db-data:/data/db
 #      - log-data:/edgex/logs


### PR DESCRIPTION
Fix #115 
Updating the docker-compose configuration entries for the new device-snmp-go.
Including the image name as it will be named for the edinburgh release.

Signed-off-by: xmlviking <ecotter@gmail.com>