### PR TITLE
Fix link to Getting Started Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Developer Scripts
+
 Main Author: Jim White
 
 Copyright 2016-17, Dell, Inc.
@@ -8,42 +10,44 @@ This repos contains scripts, batch files, JSON used in REST calls and other misc
 
 For convenience there are a couple of scripts that help you get up and running
 
-### linux_setup.sh
-This script assumes:
+### Run this First
+
+**linux_setup.sh**, this script assumes:
+
 * you are starting with a fresh install of mongodb
 * that init_mongo.js has not been run before  
 
 This script will:
+
 * create the necessary folder(s) for database placement
 * start mongod without the "--auth" option
 * initialize the mongo database (via init_mongo.js)
 * restart mongod with the "--auth" option
 * leave mongo in a state of waiting for a connection.
 
-### run-it.sh
-This script will start the services
-in order as described [HERE](https://docs.edgexfoundry.org/Ch-GettingStartedUsers.html).
+### Run This Second
 
+**prepare-environment.sh**, this script will clone the set of modules you need. You can pass a list of valid modules.
 
-### prepare-environment.sh
-
-This script is used to clone from each git, the set of modules you need. You can pass a list of valid modules.
-
->MODULES: core-data-client core-domain core-exception core-test export-distro 
+>MODULES: core-data-client core-domain core-exception core-test export-distro
 >export-domain export-test support-domain support-logging-client export-client
 >support-notifications-client core-data core-metadata-client
 
-Also, if you run the script without parameters, you can choose manually which one of above do you want to be installed.
+**Note**, if you run the script without parameters, you can manually choose which modules you want to be installed.
 
+### Running EdgeX
 
-### update-packages.sh
+**run-it.sh**, this script will start the services
+in order as described [HERE](https://docs.edgexfoundry.org/Ch-GettingStartedUsers.html).
 
-This script will update the installed packages in your working copy
+### Updating EdgeX
 
-### reset-dockers.sh
+**update-packages.sh**, this script will update the installed packages in your working copy
 
-This script removes all containers and images from your environment. Very useful for development
+### Reset
 
-### create-containers.sh
+**reset-dockers.sh**, this script removes all containers and images from your environment. Very useful for development, when you want to reset everything from scratch
 
-This script creates containers and images defined in internal variable `DOCKER`
+### Containerization
+
+**create-containers.sh**, this script creates containers and images defined in the environment variable `DOCKERS`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This script will:
 
 ### run-it.sh
 This script will start the services
-in order as described [HERE](https://wiki.edgexfoundry.org/display/FA/Get+EdgeX+Foundry+-+Users).
+in order as described [HERE](https://docs.edgexfoundry.org/Ch-GettingStartedUsers.html).
 
 
 ### prepare-environment.sh


### PR DESCRIPTION
The link is currently pointing to:
https://wiki.edgexfoundry.org/display/FA/Get+EdgeX+Foundry+-+Users

Which has been replaced by:
https://docs.edgexfoundry.org/Ch-GettingStartedUsers.html

This PR updates the link