### PR TITLE
Outdated docker-compose (Edinburgh) links in README markdown

### DIFF
--- a/project-metrics/README.md
+++ b/project-metrics/README.md
@@ -4,7 +4,7 @@
 Scripts that generate Git statistics use a local checkout of EdgeX git repos. Before you run those scripts, you will need to fetch the latest contents from Github.  To do that, run:
 
 ```
-./retch_repos.sh
+./fetch_repos.sh
 ```
 
 This will create a local ./repos folder with a checkout of all the EdgeX repositories from Github.

--- a/releases/README.md
+++ b/releases/README.md
@@ -42,18 +42,14 @@ Using these Docker Compose files will require you have [access to the EdgeX Nexu
 
 Available releases include:
 
-* [`releases/edinburgh/compose-files/docker-compose-edinburgh-1.0.0.yml`](https://github.com/edgexfoundry/developer-scripts/tree/master/releases/edinburgh/compose-files/docker-compose-edinburgh-1.0.0.yml) 
-    uses the EdgeX **Edinburgh release 1.0.0** container images.
+* [`releases/edinburgh/compose-files/docker-compose-edinburgh-1.0.1.yml`](https://github.com/edgexfoundry/developer-scripts/tree/master/releases/edinburgh/compose-files/docker-compose-edinburgh-1.0.1.yml) 
+    uses the EdgeX **Edinburgh release 1.0.1** container images.
 
-* [`releases/edinburgh/compose-files/docker-compose-edinburgh-no-secty-1.0.0.yml`](https://github.com/edgexfoundry/developer-scripts/tree/master/releases/edinburgh/compose-files/docker-compose-edinburgh-no-secty-1.0.0.yml) 
-    uses the EdgeX **Edinburgh release 1.0.0** container images and does not include security services.
+* [`releases/edinburgh/compose-files/docker-compose-edinburgh-no-secty-1.0.1.yml`](https://github.com/edgexfoundry/developer-scripts/tree/master/releases/edinburgh/compose-files/docker-compose-edinburgh-no-secty-1.0.1.yml) 
+    uses the EdgeX **Edinburgh release 1.0.1** container images and does not include security services.
 
-* [`releases/edinburgh/compose-files/docker-compose-redis-edinburgh-1.0.0.yml`](https://github.com/edgexfoundry/developer-scripts/tree/master/releases/edinburgh/compose-files/docker-compose-redis-edinburgh-1.0.0.yml) 
-    uses the EdgeX **Edinburgh release 1.0.0** container images and includes the Redis container (for use when using 
-    Redis in persistence with core data, metadata or logging).
-
-* [`releases/edinburgh/compose-files/docker-compose-redis-edinburgh-no-secty-1.0.0.yml`](https://github.com/edgexfoundry/developer-scripts/tree/master/releases/edinburgh/compose-files/docker-compose-redis-edinburgh-no-secty-1.0.0.yml) 
-    uses the EdgeX **Edinburgh release 1.0.0** container images, includes the Redis container (for use when using Redis 
+* [`releases/edinburgh/compose-files/docker-compose-redis-edinburgh-no-secty-1.0.1.yml`](https://github.com/edgexfoundry/developer-scripts/tree/master/releases/edinburgh/compose-files/docker-compose-redis-edinburgh-no-secty-1.0.1.yml) 
+    uses the EdgeX **Edinburgh release 1.0.1** container images, includes the Redis container (for use when using Redis 
     in persistence with core data, metadata or logging), and does not include security services.
 
 The Docker Compose files have device service elements that have all been commented out (except for the device-virtual 

--- a/releases/edinburgh/compose-files/README.md
+++ b/releases/edinburgh/compose-files/README.md
@@ -1,2 +1,4 @@
-## Important Dot Release Note
-The Edinburgh 1.0.0 Docker Compose file was removed from this directory.  It used core, supporting, export and other 1.0.0 containers which contained a race condition.  Use the 1.0.1 Docker Compose file to get the same 1.0.0 functionality but with the critical race condition bugs removed.
+## Important Dot Release Note (1.0.0 -> 1.0.1)
+The Edinburgh 1.0.0 Docker Compose file was removed from this directory.  It used core, supporting, export and other 
+    1.0.0 containers which contained a race condition.  Use the 1.0.1 Docker Compose file to get the same 1.0.0 
+    functionality but with the critical race condition bugs removed.


### PR DESCRIPTION
Updates referenced Edinburgh file names in README.md.

Corrects misspelling.

Fixes: https://github.com/edgexfoundry/developer-scripts/issues/134

Signed-off-by: Michael W. Estrin <me@michaelestrin.com>