### PR TITLE
nightly-build/docker-compose-nexus.yml: implement dependency ordering for Kong

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -108,7 +108,7 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:1.1.0
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
-    command: ["--init=true", "--vaultInterval=10", "--insecureSkipVerify=false"]
+    command: ["--init=true", "--vaultInterval=10"]
     networks:
       edgex-network:
         aliases:
@@ -176,7 +176,7 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:1.1.0
     container_name: edgex-proxy
     hostname: edgex-proxy
-    command: ["--init=true", "--insecureSkipVerify=true"]
+    command: ["--init=true"]
     networks:
       edgex-network:
         aliases:

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -41,7 +41,7 @@ services:
       - consul-data:/consul/data
 
   consul:
-    image: consul:1.3.1
+    image: nexus3.edgexfoundry.org:10004/docker-edgex-consul:1.1.0
     ports:
       - "8400:8400"
       - "8500:8500"

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -150,8 +150,15 @@ services:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
     command: >
-      /bin/sh -c 
-      "until /consul/scripts/consul-svc-healthy.sh kong-db; do sleep 1; done && kong migrations bootstrap"
+      /bin/sh -cx 
+      'until /consul/scripts/consul-svc-healthy.sh kong-db;
+         do sleep 1;
+      done && kong migrations bootstrap;
+      kong migrations list;
+      code=$$?;
+      if [ $$code -eq 5 ]; then
+        kong migrations up && kong migrations finish;
+      fi'
     volumes:
       - consul-scripts:/consul/scripts
     depends_on:

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -150,7 +150,9 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
-    command: "kong migrations bootstrap"
+    command: >
+      /bin/sh -c 
+      "until /consul/scripts/consul-svc-healthy.sh kong-db; do sleep 1; done && kong migrations bootstrap"
     volumes:
       - consul-scripts:/consul/scripts
     depends_on:
@@ -179,6 +181,10 @@ services:
         - 'KONG_PROXY_ERROR_LOG=/dev/stderr'
         - 'KONG_ADMIN_ERROR_LOG=/dev/stderr'
         - 'KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl'
+    command: >
+      /bin/sh -c 
+      "until /consul/scripts/consul-svc-healthy.sh kong-migrations; do sleep 1; done;
+      /docker-entrypoint.sh kong docker-start"
     volumes:
       - consul-scripts:/consul/scripts
     depends_on:

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -22,6 +22,7 @@ volumes:
   log-data:
   consul-config:
   consul-data:
+  consul-scripts:
   portainer_data:
   vault-config:
   vault-file:
@@ -56,6 +57,7 @@ services:
       - log-data:/edgex/logs
       - consul-config:/consul/config
       - consul-data:/consul/data
+      - consul-scripts:/consul/scripts
     depends_on:
       - volume
 
@@ -100,6 +102,7 @@ services:
       - vault-logs:/vault/logs
       - secrets-setup-cache:/etc/edgex/pki
       - vault-config:/vault/config
+      - consul-scripts:/consul/scripts
     depends_on:
       - volume
       - consul
@@ -115,6 +118,7 @@ services:
             - edgex-vault-worker
     volumes:
       - vault-config:/vault/config
+      - consul-scripts:/consul/scripts
     depends_on:
       - volume
       - consul
@@ -147,6 +151,8 @@ services:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
     command: "kong migrations bootstrap"
+    volumes:
+      - consul-scripts:/consul/scripts
     depends_on:
       - kong-db
       - volume
@@ -173,6 +179,8 @@ services:
         - 'KONG_PROXY_ERROR_LOG=/dev/stderr'
         - 'KONG_ADMIN_ERROR_LOG=/dev/stderr'
         - 'KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl'
+    volumes:
+      - consul-scripts:/consul/scripts
     depends_on:
         - kong-db
         - kong-migrations

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -147,6 +147,10 @@ services:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
     command: "kong migrations bootstrap"
+    depends_on:
+      - kong-db
+      - volume
+      - consul
 
   kong:
     image: "kong:1.0.3"
@@ -171,6 +175,9 @@ services:
         - 'KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl'
     depends_on:
         - kong-db
+        - kong-migrations
+        - volume
+        - consul
 
   edgex-proxy:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:1.1.0

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -141,12 +141,11 @@ services:
 
   kong-migrations:
     image: "kong:1.0.3"
-    container_name: kong-migration
-    hostname: kong-migration
+    container_name: kong-migrations
     networks:
       edgex-network:
         aliases:
-            - kong-migration
+            - kong-migrations
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -181,6 +181,7 @@ services:
         - 'KONG_PROXY_ERROR_LOG=/dev/stderr'
         - 'KONG_ADMIN_ERROR_LOG=/dev/stderr'
         - 'KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl'
+    restart: on-failure
     command: >
       /bin/sh -c 
       "until /consul/scripts/consul-svc-healthy.sh kong-migrations; do sleep 1; done;


### PR DESCRIPTION
This PR implements dependency ordering for the Kong services. It is dependent on the new updates to the docker containers implemented in:
 - [x] https://github.com/edgexfoundry/docker-edgex-consul/pull/2
 - [x] https://github.com/edgexfoundry/docker-edgex-volume/pull/9

These have been merged, so this should run without modification to this PR and you can use the containers from nexus.

After this, you can see that kong-db, kong-migrations, and then finally kong all become active in the consul services page.

Also check that kong-migrations performs the check on kong-db before actually running the migraiton:
```
$ docker logs kong-migration
+ cd /consul/scripts
+ LD_LIBRARY_PATH=.
+ export LD_LIBRARY_PATH
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ /consul/scripts/jq -r '.[] | select(.ServiceName == "kong-db") | .Status == "passing"'
+ '[' true '=' true ]
bootstrapping database...
migrating core on database 'kong'...
core migrated up to: 000_base (executed)
core migrated up to: 001_14_to_15 (executed)
core migrated up to: 002_15_to_1 (executed)
migrating oauth2 on database 'kong'...
oauth2 migrated up to: 000_base_oauth2 (executed)
oauth2 migrated up to: 001_14_to_15 (executed)
oauth2 migrated up to: 002_15_to_10 (executed)
migrating acl on database 'kong'...
acl migrated up to: 000_base_acl (executed)
acl migrated up to: 001_14_to_15 (executed)
migrating jwt on database 'kong'...
jwt migrated up to: 000_base_jwt (executed)
jwt migrated up to: 001_14_to_15 (executed)
migrating basic-auth on database 'kong'...
basic-auth migrated up to: 000_base_basic_auth (executed)
basic-auth migrated up to: 001_14_to_15 (executed)
migrating key-auth on database 'kong'...
key-auth migrated up to: 000_base_key_auth (executed)
key-auth migrated up to: 001_14_to_15 (executed)
migrating rate-limiting on database 'kong'...
rate-limiting migrated up to: 000_base_rate_limiting (executed)
rate-limiting migrated up to: 001_14_to_15 (executed)
rate-limiting migrated up to: 002_15_to_10 (executed)
migrating hmac-auth on database 'kong'...
hmac-auth migrated up to: 000_base_hmac_auth (executed)
hmac-auth migrated up to: 001_14_to_15 (executed)
migrating response-ratelimiting on database 'kong'...
response-ratelimiting migrated up to: 000_base_response_rate_limiting (executed)
response-ratelimiting migrated up to: 001_14_to_15 (executed)
response-ratelimiting migrated up to: 002_15_to_10 (executed)
22 migrations processed
22 executed
database is up-to-date
```

and that kong also blocks waiting for kong-migrations to be done, and then after starting kong will respond to the consul checks with a passing status:
```
$ docker logs kong
+ cd /consul/scripts
+ LD_LIBRARY_PATH=.
+ export LD_LIBRARY_PATH
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ /consul/scripts/jq -r '.[] | select(.ServiceName == "kong-migrations") | .Status == "passing"'
+ '[' true '=' false ]
+ exit 2
+ cd /consul/scripts
+ LD_LIBRARY_PATH=.
+ export LD_LIBRARY_PATH
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ /consul/scripts/jq -r '.[] | select(.ServiceName == "kong-migrations") | .Status == "passing"'
+ '[' true '=' false ]
+ exit 2
+ cd /consul/scripts
+ LD_LIBRARY_PATH=.
+ export LD_LIBRARY_PATH
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ /consul/scripts/jq -r '.[] | select(.ServiceName == "kong-migrations") | .Status == "passing"'
+ '[' true '=' false ]
+ exit 2
+ cd /consul/scripts
+ LD_LIBRARY_PATH=.
+ export LD_LIBRARY_PATH
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ /consul/scripts/jq -r '.[] | select(.ServiceName == "kong-migrations") | .Status == "passing"'
+ '[' true '=' true ]
2019/10/18 16:07:40 [warn] ulimit is currently set to "1024". For better performance set it to at least "4096" using "ulimit -n"
2019/10/18 16:07:41 [notice] 1#0: using the "epoll" event method
2019/10/18 16:07:41 [notice] 1#0: openresty/1.13.6.2
2019/10/18 16:07:41 [notice] 1#0: built by gcc 6.3.0 (Alpine 6.3.0) 
2019/10/18 16:07:41 [notice] 1#0: OS: Linux 5.0.0-32-generic
2019/10/18 16:07:41 [notice] 1#0: getrlimit(RLIMIT_NOFILE): 1024:524288
2019/10/18 16:07:41 [notice] 1#0: start worker processes
2019/10/18 16:07:41 [notice] 1#0: start worker process 54 
....
172.25.0.4 - - [18/Oct/2019:16:07:42 +0000] "GET /status HTTP/1.1" 200 205 "-" "Consul Health Check"
```

Finally, check that the kong-db consul health checks work properly by asking consul for them:

```
$ curl -s localhost:8500/v1/agent/checks | jq -r '."service:kong-db".Output'
kong-db:5432 - accepting connections

```