### PR TITLE
LICENSE: retroactively add proper Copyright to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2017 Dell
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
While the LICENSE file was first committed by myself (see #105), the project's origin was from Dell in 2017 as per git history.

CC @jpwhitemn 