### PR TITLE
Fix issue #150: MacOS compatibility issue of /run

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -112,8 +112,9 @@ services:
           max_lease_ttl = "720h"
       - VAULT_CONFIG_DIR=/vault/config
       - VAULT_UI=true
+    # create the tempfs directory inside the container for deployed purpose
     tmpfs:
-      - /run
+      - /run/edgex/secrets/edgex-vault
     command: >
       /usr/bin/dumb-init -- /bin/sh -c 
       "./security-secrets-setup generate ;
@@ -123,7 +124,6 @@ services:
       - vault-file:/vault/file
       - vault-logs:/vault/logs
       - secrets-setup-cache:/etc/edgex/pki
-      - /run/edgex/secrets/edgex-vault:/run/edgex/secrets/edgex-vault
     depends_on:
       - volume
       - consul
@@ -383,7 +383,7 @@ services:
       - EXPORT_DISTRO_MQTTS_KEY_FILE=none
 
   rulesengine:
-    image: nexus3.edgexfoundry.org:10004/docker-support-rulesengine:1.1.0
+    image: nexus3.edgexfoundry.org:10004/docker-support-rulesengine:1.1.0-dev.1
     ports:
       - "48075:48075"
     container_name: edgex-support-rulesengine


### PR DESCRIPTION
This PR attempt to fix issue #150 

  Remove bind mount on the host system as it causes the problem of white-list mount of MacOs

  Change the tmpfs inside the docker container so that by default deploy directory exists

## To run
```sh
docker-compose -f docker-compose-nexus.yml up -d
```

## To shut it down
```sh
docker-compose -f docker-compose-nexus.yml down
```

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>