### PR TITLE
Fix issue #152: vault-worker micro service fails to start in nightly secure docker-compose

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -124,6 +124,7 @@ services:
       - vault-file:/vault/file
       - vault-logs:/vault/logs
       - secrets-setup-cache:/etc/edgex/pki
+      - vault-config:/vault/config
     depends_on:
       - volume
       - consul
@@ -132,7 +133,7 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:1.1.0
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
-    command: ["--init=true", "--vaultInterval=10", "--insecureskipverify=false"]
+    command: ["--init=true", "--vaultInterval=10", "--insecureSkipVerify=false"]
     networks:
       edgex-network:
         aliases:
@@ -200,6 +201,7 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:1.1.0
     container_name: edgex-proxy
     hostname: edgex-proxy
+    command: ["--init=true", "--insecureSkipVerify=true"]
     networks:
       edgex-network:
         aliases:


### PR DESCRIPTION
This PR attempts to fix issue #152 

  - Fix the flag name in edgex-vault-worker (insecureSkipVerify)
  - Add the missing vault-config volume from vault itself
  - Add the missing flags in edgex-proxy

## To run:
```sh
  docker-compose -f docker-compose-nexus.yml up -d
```


## To test:
After docker-compose up, run this:
```sh
sleep 15; docker ps -a | grep vault-worker | grep "Exited (0)" && echo "Pass" || echo "Failed"
```
One should expect to see `Pass` as `vault-worker` is one-time shot docker micro-service.


Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>