### PR TITLE
nightly-build/docker-compose-nexus.yml: remove insecureSkipVerify arg

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -108,7 +108,7 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:1.1.0
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
-    command: ["--init=true", "--vaultInterval=10", "--insecureSkipVerify=false"]
+    command: ["--init=true", "--vaultInterval=10"]
     networks:
       edgex-network:
         aliases:
@@ -176,7 +176,7 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:1.1.0
     container_name: edgex-proxy
     hostname: edgex-proxy
-    command: ["--init=true", "--insecureSkipVerify=true"]
+    command: ["--init=true"]
     networks:
       edgex-network:
         aliases:


### PR DESCRIPTION
This option defaults to false and so we shouldn't specify it at all for either of these containers.

See https://github.com/edgexfoundry/edgex-go/pull/1985#issuecomment-546073590

CC @jim-wang-intel @bnevis-i @tingyuz 