### PR TITLE
Fix issue #165: Edgex-vault failing to start listener with bind address already in use

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -90,36 +90,11 @@ services:
       - "IPC_LOCK"
     environment:
       - VAULT_ADDR=https://edgex-vault:8200
-      - |
-        VAULT_LOCAL_CONFIG=
-          listener "tcp" { 
-              tls_disable = "0" 
-              cluster_address = "edgex-vault:8201" 
-              tls_min_version = "tls12" 
-              tls_client_ca_file ="/run/edgex/secrets/edgex-vault/ca.pem" 
-              tls_cert_file ="/run/edgex/secrets/edgex-vault/server.crt" 
-              tls_key_file = "/run/edgex/secrets/edgex-vault/server.key" 
-              tls_perfer_server_cipher_suites = true 
-          } 
-          backend "consul" { 
-              path = "vault/" 
-              address = "edgex-core-consul:8500" 
-              scheme = "http" 
-              redirect_addr = "https://edgex-vault:8200" 
-              cluster_addr = "https://edgex-vault:8201" 
-          } 
-          default_lease_ttl = "168h" 
-          max_lease_ttl = "720h"
       - VAULT_CONFIG_DIR=/vault/config
       - VAULT_UI=true
-    # create the tempfs directory inside the container for deployed purpose
-    tmpfs:
-      - /run/edgex/secrets/edgex-vault
     command: >
       /usr/bin/dumb-init -- /bin/sh -c 
-      "./security-secrets-setup generate ;
-      chown -Rh 100:1000 /run/edgex/secrets/edgex-vault/ ;
-      exec /usr/local/bin/docker-entrypoint.sh server -log-level=info"
+      "exec /usr/local/bin/docker-entrypoint.sh server -log-level=info"
     volumes:
       - vault-file:/vault/file
       - vault-logs:/vault/logs


### PR DESCRIPTION
Fixes #165 

  Reverted changes to docker-compose to enable generate mode of operation.

  Due to code freeze, could not implement additional changes to fully transition.

  Implementation of PKI uses legacy functionality present in security-secrets-setup

  Need to remove VAULT_LOCAL_CONFIG because it duplicated the local.hcl file that was injected at container build time.

  The result was Vault creating duplicate listeners and failing
    because the cluster_address was attempted to be bound twice.
 

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>