### PR TITLE
feat(app-service-configurable-rules): Replace Export services with app-service-configurable

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
@@ -23,6 +23,10 @@ version: '3.4'
 # all common shared environment variables defined here:
 x-common-env-variables: &common-variables
   EDGEX_SECURITY_SECRET_STORE: "false"
+  edgex_registry: consul://edgex-core-consul:8500
+  Clients_CoreData_Host: edgex-core-data
+  Clients_Logging_Host: edgex-support-logging
+  Logging_EnableRemote: "true"
 
 volumes:
   db-data:
@@ -229,63 +233,81 @@ services:
     depends_on:
       - metadata
 
-  export-client:
-    image: nexus3.edgexfoundry.org:10004/docker-export-client-go:1.1.0
+  app-service-rules:
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     ports:
-      - "48071:48071"
-    container_name: edgex-export-client
-    hostname: edgex-export-client
+      - "48100:48100"
+    container_name: edgex-app-service-configurable-rules
+    hostname: edgex-app-service-configurable-rules
     networks:
-      - edgex-network
+      edgex-network:
+        aliases:
+          - edgex-app-service-configurable-rules
     environment:
       <<: *common-variables
-    volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
+      edgex_service: http://edgex-app-service-configurable-rules:48100
+      edgex_profile: rules-engine
+      Service_Host: edgex-app-service-configurable-rules
+      MessageBus_SubscribeHost_Host: edgex-core-data
     depends_on:
+      - consul
+      - logging
       - data
 
-  export-distro:
-    image: nexus3.edgexfoundry.org:10004/docker-export-distro-go:1.1.0
-    ports:
-      - "48070:48070"
-      - "5566:5566"
-    container_name: edgex-export-distro
-    hostname: edgex-export-distro
-    networks:
-      - edgex-network
-    volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-    depends_on:
-      - export-client
-    environment:
-      <<: *common-variables
-      EXPORT_DISTRO_CLIENT_HOST: export-client
-      EXPORT_DISTRO_DATA_HOST: edgex-core-data
-      EXPORT_DISTRO_CONSUL_HOST: dgex-config-seed
-      EXPORT_DISTRO_MQTTS_CERT_FILE: none
-      EXPORT_DISTRO_MQTTS_KEY_FILE: none
-
   rulesengine:
-    image: nexus3.edgexfoundry.org:10004/docker-support-rulesengine:1.0.0
+    image: nexus3.edgexfoundry.org:10004/docker-support-rulesengine:master
     ports:
       - "48075:48075"
     container_name: edgex-support-rulesengine
     hostname: edgex-support-rulesengine
     networks:
-      - edgex-network
-    volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
+      edgex-network:
+        aliases:
+          - edgex-support-rulesengine
     depends_on:
-      - export-client
+      - app-service-rules
+
+  #  export-client:
+  #    image: nexus3.edgexfoundry.org:10004/docker-export-client-go:1.1.0
+  #    ports:
+  #      - "48071:48071"
+  #    container_name: edgex-export-client
+  #    hostname: edgex-export-client
+  #    networks:
+  #      - edgex-network
+  #    environment:
+  #      <<: *common-variables
+  #    volumes:
+  #      - db-data:/data/db
+  #      - log-data:/edgex/logs
+  #      - consul-config:/consul/config
+  #      - consul-data:/consul/data
+  #    depends_on:
+  #      - data
+  #
+  #  export-distro:
+  #    image: nexus3.edgexfoundry.org:10004/docker-export-distro-go:1.1.0
+  #    ports:
+  #      - "48070:48070"
+  #      - "5566:5566"
+  #    container_name: edgex-export-distro
+  #    hostname: edgex-export-distro
+  #    networks:
+  #      - edgex-network
+  #    volumes:
+  #      - db-data:/data/db
+  #      - log-data:/edgex/logs
+  #      - consul-config:/consul/config
+  #      - consul-data:/consul/data
+  #    depends_on:
+  #      - export-client
+  #    environment:
+  #      <<: *common-variables
+  #      EXPORT_DISTRO_CLIENT_HOST: export-client
+  #      EXPORT_DISTRO_DATA_HOST: edgex-core-data
+  #      EXPORT_DISTRO_CONSUL_HOST: dgex-config-seed
+  #      EXPORT_DISTRO_MQTTS_CERT_FILE: none
+  #      EXPORT_DISTRO_MQTTS_KEY_FILE: none
 
 #################################################################
 # Device Services

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
@@ -23,6 +23,10 @@ version: '3.4'
 # all common shared environment variables defined here:
 x-common-env-variables: &common-variables
   EDGEX_SECURITY_SECRET_STORE: "false"
+  edgex_registry: consul://edgex-core-consul:8500
+  Clients_CoreData_Host: edgex-core-data
+  Clients_Logging_Host: edgex-support-logging
+  Logging_EnableRemote: "true"
 
 volumes:
   db-data:
@@ -220,60 +224,81 @@ services:
       - metadata
       - redis
 
-  export-client:
-    image: nexus3.edgexfoundry.org:10004/docker-export-client-go:1.1.0
+  app-service-rules:
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     ports:
-      - "48071:48071"
-    container_name: edgex-export-client
-    hostname: edgex-export-client
+      - "48100:48100"
+    container_name: edgex-app-service-configurable-rules
+    hostname: edgex-app-service-configurable-rules
     networks:
-      - edgex-network
+      edgex-network:
+        aliases:
+          - edgex-app-service-configurable-rules
     environment:
       <<: *common-variables
-    volumes:
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
+      edgex_service: http://edgex-app-service-configurable-rules:48100
+      edgex_profile: rules-engine
+      Service_Host: edgex-app-service-configurable-rules
+      MessageBus_SubscribeHost_Host: edgex-core-data
     depends_on:
+      - consul
+      - logging
       - data
 
-  export-distro:
-    image: nexus3.edgexfoundry.org:10004/docker-export-distro-go:1.1.0
-    ports:
-      - "48070:48070"
-      - "5566:5566"
-    container_name: edgex-export-distro
-    hostname: edgex-export-distro
-    networks:
-      - edgex-network
-    volumes:
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-    depends_on:
-      - export-client
-    environment:
-      <<: *common-variables
-      EXPORT_DISTRO_CLIENT_HOST: export-client
-      EXPORT_DISTRO_DATA_HOST: edgex-core-data
-      EXPORT_DISTRO_CONSUL_HOST: edgex-config-seed
-      EXPORT_DISTRO_MQTTS_CERT_FILE: none
-      EXPORT_DISTRO_MQTTS_KEY_FILE: none
-
   rulesengine:
-    image: nexus3.edgexfoundry.org:10004/docker-support-rulesengine:1.0.0
+    image: nexus3.edgexfoundry.org:10004/docker-support-rulesengine:master
     ports:
       - "48075:48075"
     container_name: edgex-support-rulesengine
     hostname: edgex-support-rulesengine
     networks:
-      - edgex-network
-    volumes:
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
+      edgex-network:
+        aliases:
+          - edgex-support-rulesengine
     depends_on:
-      - export-client
+      - app-service-rules
+
+  #  export-client:
+  #    image: nexus3.edgexfoundry.org:10004/docker-export-client-go:1.1.0
+  #    ports:
+  #      - "48071:48071"
+  #    container_name: edgex-export-client
+  #    hostname: edgex-export-client
+  #    networks:
+  #      - edgex-network
+  #    environment:
+  #      <<: *common-variables
+  #    volumes:
+  #      - db-data:/data/db
+  #      - log-data:/edgex/logs
+  #      - consul-config:/consul/config
+  #      - consul-data:/consul/data
+  #    depends_on:
+  #      - data
+  #
+  #  export-distro:
+  #    image: nexus3.edgexfoundry.org:10004/docker-export-distro-go:1.1.0
+  #    ports:
+  #      - "48070:48070"
+  #      - "5566:5566"
+  #    container_name: edgex-export-distro
+  #    hostname: edgex-export-distro
+  #    networks:
+  #      - edgex-network
+  #    volumes:
+  #      - db-data:/data/db
+  #      - log-data:/edgex/logs
+  #      - consul-config:/consul/config
+  #      - consul-data:/consul/data
+  #    depends_on:
+  #      - export-client
+  #    environment:
+  #      <<: *common-variables
+  #      EXPORT_DISTRO_CLIENT_HOST: export-client
+  #      EXPORT_DISTRO_DATA_HOST: edgex-core-data
+  #      EXPORT_DISTRO_CONSUL_HOST: dgex-config-seed
+  #      EXPORT_DISTRO_MQTTS_CERT_FILE: none
+  #      EXPORT_DISTRO_MQTTS_KEY_FILE: none
 
 #################################################################
 # Device Services

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -16,7 +16,15 @@
 #  * added: Jun 30, 2019
 #  *******************************************************************************/
 
-version: '3'
+version: '3.4'
+
+# all common shared environment variables defined here:
+x-common-env-variables: &common-variables
+  edgex_registry: consul://edgex-core-consul:8500
+  Clients_CoreData_Host: edgex-core-data
+  Clients_Logging_Host: edgex-support-logging
+  Logging_EnableRemote: "true"
+
 volumes:
   db-data:
   log-data:
@@ -320,60 +328,81 @@ services:
     depends_on:
       - metadata
 
-  export-client:
-    image: nexus3.edgexfoundry.org:10004/docker-export-client-go:1.1.0
+  app-service-rules:
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     ports:
-      - "48071:48071"
-    container_name: edgex-export-client
-    hostname: edgex-export-client
+      - "48100:48100"
+    container_name: edgex-app-service-configurable-rules
+    hostname: edgex-app-service-configurable-rules
     networks:
-      - edgex-network
-    volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
+      edgex-network:
+        aliases:
+          - edgex-app-service-configurable-rules
+    environment:
+      <<: *common-variables
+      edgex_service: http://edgex-app-service-configurable-rules:48100
+      edgex_profile: rules-engine
+      Service_Host: edgex-app-service-configurable-rules
+      MessageBus_SubscribeHost_Host: edgex-core-data
     depends_on:
+      - consul
+      - logging
       - data
 
-  export-distro:
-    image: nexus3.edgexfoundry.org:10004/docker-export-distro-go:1.1.0
-    ports:
-      - "48070:48070"
-      - "5566:5566"
-    container_name: edgex-export-distro
-    hostname: edgex-export-distro
-    networks:
-      - edgex-network
-    volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-    depends_on:
-      - export-client
-    environment:
-      - EXPORT_DISTRO_CLIENT_HOST=export-client
-      - EXPORT_DISTRO_DATA_HOST=edgex-core-data
-      - EXPORT_DISTRO_CONSUL_HOST=edgex-config-seed
-      - EXPORT_DISTRO_MQTTS_CERT_FILE=none
-      - EXPORT_DISTRO_MQTTS_KEY_FILE=none
-
   rulesengine:
-    image: nexus3.edgexfoundry.org:10004/docker-support-rulesengine:1.0.0
+    image: nexus3.edgexfoundry.org:10004/docker-support-rulesengine:master
     ports:
       - "48075:48075"
     container_name: edgex-support-rulesengine
     hostname: edgex-support-rulesengine
     networks:
-      - edgex-network
-    volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
+      edgex-network:
+        aliases:
+          - edgex-support-rulesengine
     depends_on:
-      - export-client
+      - app-service-rules
+
+  #  export-client:
+  #    image: nexus3.edgexfoundry.org:10004/docker-export-client-go:1.1.0
+  #    ports:
+  #      - "48071:48071"
+  #    container_name: edgex-export-client
+  #    hostname: edgex-export-client
+  #    networks:
+  #      - edgex-network
+  #    environment:
+  #      <<: *common-variables
+  #    volumes:
+  #      - db-data:/data/db
+  #      - log-data:/edgex/logs
+  #      - consul-config:/consul/config
+  #      - consul-data:/consul/data
+  #    depends_on:
+  #      - data
+  #
+  #  export-distro:
+  #    image: nexus3.edgexfoundry.org:10004/docker-export-distro-go:1.1.0
+  #    ports:
+  #      - "48070:48070"
+  #      - "5566:5566"
+  #    container_name: edgex-export-distro
+  #    hostname: edgex-export-distro
+  #    networks:
+  #      - edgex-network
+  #    volumes:
+  #      - db-data:/data/db
+  #      - log-data:/edgex/logs
+  #      - consul-config:/consul/config
+  #      - consul-data:/consul/data
+  #    depends_on:
+  #      - export-client
+  #    environment:
+  #      <<: *common-variables
+  #      EXPORT_DISTRO_CLIENT_HOST: export-client
+  #      EXPORT_DISTRO_DATA_HOST: edgex-core-data
+  #      EXPORT_DISTRO_CONSUL_HOST: dgex-config-seed
+  #      EXPORT_DISTRO_MQTTS_CERT_FILE: none
+  #      EXPORT_DISTRO_MQTTS_KEY_FILE: none
 
 #################################################################
 # Device Services


### PR DESCRIPTION
New default is for app-service-configurable running rules-engine profile to provide the event message to the rules engine.

closes #168