### PR TITLE
Restart Mongo container up to 5 times, if fail to read secrets

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
@@ -87,6 +87,7 @@ services:
       - "27017:27017"
     container_name: edgex-mongo
     hostname: edgex-mongo
+    restart: "on-failure: 5"
     networks:
       - edgex-network
     environment:

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -224,6 +224,7 @@ services:
       - "27017:27017"
     container_name: edgex-mongo
     hostname: edgex-mongo
+    restart: "on-failure: 5"
     networks:
       - edgex-network
     volumes:


### PR DESCRIPTION
Because at the time Mongo contaner gets up and tries to read secrets,
Vault-Worker could still not be ready with it tasks - and the secrets
could not be available in the secret store - edgex-mongo fails to start. 
Ref https://github.com/edgexfoundry/developer-scripts/pull/147

To handle the problem, a restart on-failure:5 is added.

Fix: https://github.com/edgexfoundry/developer-scripts/issues/167 

Signed-off-by: difince <dianaa@vmware.com>