### PR TITLE
nightly-build/docker-compose-nexus.yml: use consul script for sec svcs

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -58,6 +58,7 @@ services:
       - consul-config:/consul/config
       - consul-data:/consul/data
       - consul-scripts:/consul/scripts
+      - vault-config:/vault/config
     depends_on:
       - volume
 
@@ -111,7 +112,10 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:1.1.0
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
-    command: ["--init=true", "--vaultInterval=10"]
+    entrypoint: >
+      /bin/sh -c 
+      "until /consul/scripts/consul-svc-healthy.sh security-secrets-setup; do sleep 1; done;
+      /security-secretstore-setup --init=true --vaultInterval=10"
     networks:
       edgex-network:
         aliases:
@@ -204,13 +208,18 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:1.1.0
     container_name: edgex-proxy
     hostname: edgex-proxy
-    command: ["--init=true"]
+    entrypoint: >
+      /bin/sh -c 
+      "until /consul/scripts/consul-svc-healthy.sh kong; do sleep 1; done;
+      until /consul/scripts/consul-svc-healthy.sh security-secretstore-setup; do sleep 1; done;
+      /edgex/security-proxy-setup --init=true"
     networks:
       edgex-network:
         aliases:
             - edgex-proxy
     volumes:
-        - vault-config:/vault/config
+      - vault-config:/vault/config
+      - consul-scripts:/consul/scripts
     depends_on:
         - vault
         - kong-db


### PR DESCRIPTION
The consul svc status script from docker-edgex-consul can now be used to wait for services to be ready as defined by Consul before running their full command. 

Note we use `entrypoint` to override a hard-coded ENTRYPOINT in the image, we can't use command like we do for the other containers (i.e. kong and vault and postgres, etc.)

Also add the vault-config volume to consul so that consul can check for the existence of the TLS files.

This PR depends on a PR in edgex-go which will enable running these entrypoint overrides in the security-secretstore-setup and security-proxy-setup images, because the current is missing curl and the latter is based on scratch and thus has no `/bin/sh` or curl. That edgex-go PR is here: https://github.com/edgexfoundry/edgex-go/pull/2075. 

This PR also depends on https://github.com/edgexfoundry/docker-edgex-consul/pull/6 and https://github.com/edgexfoundry/docker-edgex-volume/pull/11 which together setup proper service definitions in Consul for the security services and allow one to check their status like we do with these scripts. 

## Testing instructions

### Building the containers
In order to test this change, you first will have to build the following docker containers locally:
* security-secretstore-setup-go:1.1.0-dev (from edgex-go repo)
* security-proxy-setup-go:1.1.0-dev (from edgex-go repo)
* docker-edgex-volume (from docker-edgex-volume repo)
* docker-edgex-consul (from docker-edgex-consul repo)

**_NOTE_**: if you are building on windows you will probably need to fix your line endings if you use git for windows and have the setting which changes unix line endings to windows line endings on git checkout, and the inverse on git commit. To do that, see this comment: https://github.com/edgexfoundry/developer-scripts/pull/147#issuecomment-545252907 for how to use dos2unix and do that. See also https://github.com/edgexfoundry/developer-scripts/issues/156

To build these containers, assuming you have fixed your line endings to be Unix style, checkout the edgex-go PR (https://github.com/edgexfoundry/edgex-go/pull/2075) and in the edgex-go repo and run:
```
$ make docker_security_secretstore_setup docker_security_proxy_setup
```
Then checkout the docker-edgex-volume PR (https://github.com/edgexfoundry/docker-edgex-volume/pull/11) and in the docker-edgex-volume repo run:
```
$ make docker
```

Then do the same for docker-edgex-consul, checking out the PR (https://github.com/edgexfoundry/docker-edgex-consul/pull/6) and in the docker-edgex-consul repo run:
```
$ make docker
```

## Launching containers with docker-compose

Finally, after having built all of these containers locally, checkout this PR in your local developer-scripts repo and apply this patch on top to use your local containers:
```patch
diff --git a/releases/nightly-build/compose-files/docker-compose-nexus.yml b/releases/nightly-build/compose-files/docker-compose-nexus.yml
index 634e60d..b09f220 100644
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -31,7 +31,7 @@ volumes:
 
 services:
   volume:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-volume:1.1.0
+    image: edgexfoundry/docker-edgex-volume:1.1.0
     container_name: edgex-files
     networks:
       - edgex-network
@@ -42,7 +42,7 @@ services:
       - consul-data:/consul/data
 
   consul:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-consul:1.1.0
+    image: edgexfoundry/docker-edgex-consul:1.1.0
     ports:
       - "8400:8400"
       - "8500:8500"
@@ -109,7 +109,7 @@ services:
       - consul
 
   vault-worker:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:1.1.0
+    image: edgexfoundry/docker-edgex-security-secretstore-setup-go:1.1.0-dev
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
     entrypoint: >
@@ -205,7 +205,7 @@ services:
         - consul
 
   edgex-proxy:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:1.1.0
+    image: edgexfoundry/docker-edgex-security-proxy-setup-go:1.1.0-dev
     container_name: edgex-proxy
     hostname: edgex-proxy
     entrypoint: >
```
and then run:
```
$ docker volume prune -f
$ docker-compose -f ./releases/nightly-build/compose-files/docker-compose-nexus.yml up -d
```
The docker volume prune is necessary in case some of the volumes on your machine are stale. It's not totally clear to me when docker will "refresh" those volumes, so I just always prune before running with a modified docker-edgex-volume container.

### Confirming container status

The final part of this is the actual test to ensure that we didn't start containers until their dependencies were ready. To check this first, inspect Consul using the web UI to see that the following services are healthy:
- security-secrets-setup
- security-secretstore-setup
- security-proxy-setup

And then check to see that the logs indicate we waited for the dependencies before launching things, i.e. your output should match something like this:
<details> <summary>edgex-proxy</summary>

```
$ docker logs edgex-proxy
+ cd /consul/scripts
+ LD_LIBRARY_PATH=.
+ export LD_LIBRARY_PATH
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ /consul/scripts/jq -r '.[] | select(.ServiceName == "kong") | .Status == "passing"'
+ '[' true '=' false ]
+ exit 2
+ cd /consul/scripts
+ LD_LIBRARY_PATH=.
+ export LD_LIBRARY_PATH
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ /consul/scripts/jq -r '.[] | select(.ServiceName == "kong") | .Status == "passing"'
+ '[' true '=' true ]
+ cd /consul/scripts
+ LD_LIBRARY_PATH=.
+ export LD_LIBRARY_PATH
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ /consul/scripts/jq -r '.[] | select(.ServiceName == "security-secretstore-setup") | .Status == "passing"'
+ '[' true '=' true ]
level=ERROR ts=2019-11-05T14:23:54.433502518Z app=edgex-security-proxy-setup source=logger.go:73 msg="logTarget cannot be blank, using stdout only"
Creating directory: ./logs
level=INFO ts=2019-11-05T14:23:54.435045762Z app=edgex-security-proxy-setup source=requestor.go:40 msg="successfully loaded rootCA certificate."
level=INFO ts=2019-11-05T14:23:54.445048682Z app=edgex-security-proxy-setup source=service.go:64 msg="the service on http://kong:8001 is up successfully"
level=DEBUG ts=2019-11-05T14:23:54.481261855Z app=edgex-security-proxy-setup source=service.go:147 msg="trying to upload cert to proxy server"
level=INFO ts=2019-11-05T14:23:54.501628261Z app=edgex-security-proxy-setup source=service.go:169 msg="successfully added certificate to the reverse proxy"
level=INFO ts=2019-11-05T14:23:54.512814498Z app=edgex-security-proxy-setup source=service.go:207 msg="successful to set up proxy service for virtualdevice"
level=INFO ts=2019-11-05T14:23:54.526769015Z app=edgex-security-proxy-setup source=service.go:245 msg="successful to set up route for virtualdevice"
level=INFO ts=2019-11-05T14:23:54.5406004Z app=edgex-security-proxy-setup source=service.go:207 msg="successful to set up proxy service for scheduler"
level=INFO ts=2019-11-05T14:23:54.554741057Z app=edgex-security-proxy-setup source=service.go:245 msg="successful to set up route for scheduler"
level=INFO ts=2019-11-05T14:23:54.565040021Z app=edgex-security-proxy-setup source=service.go:207 msg="successful to set up proxy service for coredata"
level=INFO ts=2019-11-05T14:23:54.577040483Z app=edgex-security-proxy-setup source=service.go:245 msg="successful to set up route for coredata"
level=INFO ts=2019-11-05T14:23:54.586869839Z app=edgex-security-proxy-setup source=service.go:207 msg="successful to set up proxy service for metadata"
level=INFO ts=2019-11-05T14:23:54.599601208Z app=edgex-security-proxy-setup source=service.go:245 msg="successful to set up route for metadata"
level=INFO ts=2019-11-05T14:23:54.609177093Z app=edgex-security-proxy-setup source=service.go:207 msg="successful to set up proxy service for command"
level=INFO ts=2019-11-05T14:23:54.621533181Z app=edgex-security-proxy-setup source=service.go:245 msg="successful to set up route for command"
level=INFO ts=2019-11-05T14:23:54.63016803Z app=edgex-security-proxy-setup source=service.go:207 msg="successful to set up proxy service for notifications"
level=INFO ts=2019-11-05T14:23:54.642725946Z app=edgex-security-proxy-setup source=service.go:245 msg="successful to set up route for notifications"
level=INFO ts=2019-11-05T14:23:54.65363021Z app=edgex-security-proxy-setup source=service.go:207 msg="successful to set up proxy service for distro"
level=INFO ts=2019-11-05T14:23:54.665608905Z app=edgex-security-proxy-setup source=service.go:245 msg="successful to set up route for distro"
level=INFO ts=2019-11-05T14:23:54.674066765Z app=edgex-security-proxy-setup source=service.go:207 msg="successful to set up proxy service for export"
level=INFO ts=2019-11-05T14:23:54.686946874Z app=edgex-security-proxy-setup source=service.go:245 msg="successful to set up route for export"
level=INFO ts=2019-11-05T14:23:54.696107656Z app=edgex-security-proxy-setup source=service.go:207 msg="successful to set up proxy service for logging"
level=INFO ts=2019-11-05T14:23:54.708397713Z app=edgex-security-proxy-setup source=service.go:245 msg="successful to set up route for logging"
level=INFO ts=2019-11-05T14:23:54.718282543Z app=edgex-security-proxy-setup source=service.go:207 msg="successful to set up proxy service for rulesengine"
level=INFO ts=2019-11-05T14:23:54.730927746Z app=edgex-security-proxy-setup source=service.go:245 msg="successful to set up route for rulesengine"
level=INFO ts=2019-11-05T14:23:54.735125056Z app=edgex-security-proxy-setup source=service.go:296 msg="selected authetication method as jwt."
level=INFO ts=2019-11-05T14:23:54.762396676Z app=edgex-security-proxy-setup source=service.go:330 msg="successful to set up jwt authentication"
level=INFO ts=2019-11-05T14:23:54.781916606Z app=edgex-security-proxy-setup source=service.go:285 msg="acl set up successfully"
level=INFO ts=2019-11-05T14:23:54.786466747Z app=edgex-security-proxy-setup source=service.go:131 msg="finishing initialization for reverse proxy"
```


</details>


<details> <summary>edgex-vault-worker</summary>

```
$ docker logs edgex-vault-worker
+ cd /consul/scripts
+ LD_LIBRARY_PATH=.
+ export LD_LIBRARY_PATH
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ /consul/scripts/jq -r '.[] | select(.ServiceName == "security-secrets-setup") | .Status == "passing"'
+ '[' true '=' true ]
level=ERROR ts=2019-11-05T14:23:50.416771419Z app=edgex-security-secretstore-setup source=logger.go:73 msg="logTarget cannot be blank, using stdout only"
Creating directory: ./logs
level=INFO ts=2019-11-05T14:23:50.418130733Z app=edgex-security-secretstore-setup source=requester.go:40 msg="successfully loaded rootCA certificate."
level=INFO ts=2019-11-05T14:23:50.468952893Z app=edgex-security-secretstore-setup source=vault.go:56 msg="vault health check HTTP status: 501 Not Implemented (StatusCode: 501)"
level=INFO ts=2019-11-05T14:23:50.496984978Z app=edgex-security-secretstore-setup source=main.go:113 msg="vault is not initialized (status code: 501). Starting initialisation and unseal phases"
level=INFO ts=2019-11-05T14:23:50.530084383Z app=edgex-security-secretstore-setup source=vault.go:67 msg="vault init strategy (SSS parameters): shares=5 threshold=3"
level=INFO ts=2019-11-05T14:23:51.115404833Z app=edgex-security-secretstore-setup source=vault.go:197 msg="successfully made request to initialize secret store"
level=INFO ts=2019-11-05T14:23:51.135781029Z app=edgex-security-secretstore-setup source=vault.go:76 msg="Vault unsealing Process. Applying key shares."
level=INFO ts=2019-11-05T14:23:51.149774698Z app=edgex-security-secretstore-setup source=vault.go:110 msg="Vault key share 1/5 successfully applied."
level=INFO ts=2019-11-05T14:23:51.158219731Z app=edgex-security-secretstore-setup source=vault.go:110 msg="Vault key share 2/5 successfully applied."
level=INFO ts=2019-11-05T14:23:51.164166551Z app=edgex-security-secretstore-setup source=vault.go:110 msg="Vault key share 3/5 successfully applied."
level=INFO ts=2019-11-05T14:23:51.171294743Z app=edgex-security-secretstore-setup source=vault.go:112 msg="Vault key share threshold reached. Unsealing complete."
level=INFO ts=2019-11-05T14:23:52.180573515Z app=edgex-security-secretstore-setup source=vault.go:56 msg="vault health check HTTP status: 200 OK (StatusCode: 200)"
level=WARN ts=2019-11-05T14:23:52.186397774Z app=edgex-security-secretstore-setup source=main.go:169 msg="WARNING: The gokey generator is a reference implementation for credential generation and the underlying libraries not been reviewed for cryptographic security. The user is encouraged to perform their own security investigation before deployment."
level=INFO ts=2019-11-05T14:23:52.226837466Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/mongo/authorization, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:52.234331922Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.277067293Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.289570918Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/metadata/mongodb, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:52.293905194Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.331076635Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.339408951Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/mongo/metadata, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:52.343175676Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.378878074Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.389473924Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/rulesengine/mongodb, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:52.393995151Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.441834115Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.448433285Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/mongo/rulesengine, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:52.453473556Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.487672582Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.497018158Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/logging/mongodb, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:52.500810674Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.531826408Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.536591774Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/mongo/logging, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:52.540880412Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.617075493Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.634944389Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/coredata/mongodb, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:52.639259368Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.716829082Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.952782232Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/mongo/coredata, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:52.95986303Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:52.990809814Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.000313216Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/notifications/mongodb, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:53.007188702Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.070609635Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.076118919Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/mongo/notifications, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:53.07991196Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.114293557Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.123275298Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/exportclient/mongodb, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:53.126445278Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.15935202Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.16408111Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/mongo/exportclient, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:53.168431715Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.203197221Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.212065299Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/mongo/local, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:53.215776133Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.249105766Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.257581053Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/scheduler/mongodb, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:53.261528456Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.292080706Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.297665752Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/mongo/scheduler, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:53.300654216Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.336706662Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.347035974Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/appservice/mongodb, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:53.35133911Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.381354335Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.386306966Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/mongo/application-service, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:53.390552221Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.421472274Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.430092212Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/mongo/admin, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:53.433943468Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.464210674Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.478789121Z app=edgex-security-secretstore-setup source=password.go:133 msg="credential pair NOT found in secret store @//v1/secret/edgex/mongo/config, status: 404 Not Found"
level=DEBUG ts=2019-11-05T14:23:53.482721018Z app=edgex-security-secretstore-setup source=password.go:179 msg="trying to upload the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.542428745Z app=edgex-security-secretstore-setup source=password.go:214 msg="successfully uploaded the credential pair into secret store"
level=INFO ts=2019-11-05T14:23:53.547778224Z app=edgex-security-secretstore-setup source=certs.go:101 msg="proxy cert pair NOT found in secret store @/v1/secret/edgex/pki/tls/edgex-kong, status: 404 Not Found"
level=INFO ts=2019-11-05T14:23:53.554678717Z app=edgex-security-secretstore-setup source=main.go:233 msg="proxy certificate pair are not in the secret store yet, uploading them"
level=INFO ts=2019-11-05T14:23:53.558883652Z app=edgex-security-secretstore-setup source=main.go:240 msg="proxy certificate pair are loaded from volume successfully, will upload to secret store"
level=INFO ts=2019-11-05T14:23:53.562660874Z app=edgex-security-secretstore-setup source=certs.go:185 msg="trying to upload the proxy cert pair into secret store"
level=INFO ts=2019-11-05T14:23:53.628419153Z app=edgex-security-secretstore-setup source=certs.go:220 msg="successful on uploading the proxy cert pair into secret store"
level=INFO ts=2019-11-05T14:23:53.632395578Z app=edgex-security-secretstore-setup source=main.go:249 msg="proxy certificate pair are uploaded to secret store successfully, Vault init done successfully"
```


</details>

Finally, you should be able to check that you can talk to Kong over HTTPS with TLS certs that have been generated by security-secrets-setup like so:
```
$ docker exec -it edgex-vault /bin/sh -c "cat /vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem" > edgex-ca.pem
$ $ curl --cacert edgex-ca.pem --resolve edgex-kong:8443:127.0.0.1 https://edgex-kong:8443; echo
{"message":"no Route matched with those values"}
```
Previously, you wouldn't see the `no Route matched with those values` message from Kong with this command because security-proxy-setup wouldn't have run and uploaded the certificates to Kong, so instead you would see something like
```
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```
because Kong would be responding with it's default HTTPS certificate which isn't from the certificate authority generated by security-secrets-setup.


See https://github.com/edgexfoundry/edgex-go/issues/1710 for full details on this task.