### PR TITLE
releases/nightly-build/docker-compose-nexus.yml: make mongo wait for sec svcs

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -241,10 +241,15 @@ services:
       - "27017:27017"
     container_name: edgex-mongo
     hostname: edgex-mongo
+    entrypoint: >
+      /bin/sh -c 
+      "until /consul/scripts/consul-svc-healthy.sh security-secretstore-setup; do sleep 1; done;
+      /edgex-mongo/bin/edgex-mongo-launch.sh"
     networks:
       - edgex-network
     volumes:
       - vault-config:/vault/config
+      - consul-scripts:/consul/scripts
     depends_on:
       - volume
       - vault-worker


### PR DESCRIPTION
edgex-mongo needs security-secretstore-setup to have run before it can use the root token to access Vault and configure the database passwords stored in Vault to be usable with MongoDB.

Note that because the edgex-mongo image is Ubuntu based, this requires a corresponding change to the consul-svc-healthy.sh script to work since that script currently is hard-coded to assume the base image is Alpine/musl based. That PR is open here: https://github.com/edgexfoundry/docker-edgex-consul/pull/7

To test this, you will still need to build the following docker images locally:
- docker-edgex-security-secretstore-go
- docker-edgex-security-proxy-go
- docker-edgex-volume
- docker-edgex-consul
- docker-edgex-mongo

Then after building those locally, all from the fuji branch (or in the case of docker-edgex-consul, from the above referenced PR), apply this patch to developer-scripts repo to use those local docker images:

```patch
diff --git a/releases/nightly-build/compose-files/docker-compose-nexus.yml b/releases/nightly-build/compose-files/docker-compose-nexus.yml
index ab3b01a..1a374fd 100644
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -39,7 +39,7 @@ volumes:
 
 services:
   volume:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-volume:1.1.0
+    image: edgexfoundry/docker-edgex-volume:1.1.0
     container_name: edgex-files
     networks:
       - edgex-network
@@ -50,7 +50,7 @@ services:
       - consul-data:/consul/data
 
   consul:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-consul:1.1.0
+    image: edgexfoundry/docker-edgex-consul:1.1.0
     ports:
       - "8400:8400"
       - "8500:8500"
@@ -117,7 +117,7 @@ services:
       - consul
 
   vault-worker:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:1.1.0
+    image: edgexfoundry/docker-edgex-security-secretstore-setup-go:1.1.0-dev
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
     entrypoint: >
@@ -213,7 +213,7 @@ services:
         - consul
 
   edgex-proxy:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:1.1.0
+    image: edgexfoundry/docker-edgex-security-proxy-setup-go:1.1.0-dev
     container_name: edgex-proxy
     hostname: edgex-proxy
     entrypoint: >
@@ -236,7 +236,7 @@ services:
 # end of containers for reverse proxy
 
   mongo:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-mongo:1.1.0
+    image: edgexfoundry/docker-edgex-mongo:1.1.0
     ports:
       - "27017:27017"
     container_name: edgex-mongo
```

And prune your volumes:

```
$ docker volume prune -f
```

and finally bring everything up:

```
$ docker-compose -f ./releases/nightly-build/compose-files/docker-compose-nexus.yml up -d
```

and observe edgex-mongo startup properly:

<details> <summary>edgex-mongo logs</summary>

```
$ docker logs edgex-mongo
+ cd /consul/scripts
+ command -v jq
+ JQ=/usr/bin/jq
+ [ -z /usr/bin/jq ]
+ export JQ
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ /usr/bin/jq -r .[] | select(.ServiceName == "security-secretstore-setup") | .Status == "passing"
+ [ true = false ]
+ exit 2
+ cd /consul/scripts
+ command -v jq
+ JQ=/usr/bin/jq
+ [ -z /usr/bin/jq ]
+ export JQ
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ /usr/bin/jq -r .[] | select(.ServiceName == "security-secretstore-setup") | .Status == "passing"
+ [ true = false ]
+ exit 2
+ cd /consul/scripts
+ command -v jq
+ JQ=/usr/bin/jq
+ [ -z /usr/bin/jq ]
+ export JQ
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ /usr/bin/jq -r .[] | select(.ServiceName == "security-secretstore-setup") | .Status == "passing"
+ [ true = true ]
level=ERROR ts=2019-11-07T02:10:28.125674947Z app=edgex-mongo source=logger.go:105 msg="logTarget cannot be blank, using stdout only"
level=INFO ts=2019-11-07T02:10:28.125772082Z app=edgex-mongo source=main.go:32 msg="starting edgex-mongo process ..."
level=INFO ts=2019-11-07T02:10:28.125796168Z app=edgex-mongo source=config.go:39 msg="loading configuration considering the secret store"
level=INFO ts=2019-11-07T02:10:28.125817588Z app=edgex-mongo source=init.go:47 msg="config file location: res/docker/configuration.toml"
2019-11-07T02:10:28.141+0000 I  CONTROL  [main] Automatically disabling TLS 1.0, to force-enable TLS 1.0 specify --sslDisabledProtocols 'none'
2019-11-07T02:10:28.144+0000 I  CONTROL  [initandlisten] MongoDB starting : pid=29 port=27017 dbpath=/data/db 64-bit host=edgex-mongo
2019-11-07T02:10:28.144+0000 I  CONTROL  [initandlisten] db version v4.2.0
2019-11-07T02:10:28.144+0000 I  CONTROL  [initandlisten] git version: a4b751dcf51dd249c5865812b390cfd1c0129c30
2019-11-07T02:10:28.144+0000 I  CONTROL  [initandlisten] OpenSSL version: OpenSSL 1.1.1  11 Sep 2018
2019-11-07T02:10:28.144+0000 I  CONTROL  [initandlisten] allocator: tcmalloc
2019-11-07T02:10:28.144+0000 I  CONTROL  [initandlisten] modules: none
2019-11-07T02:10:28.144+0000 I  CONTROL  [initandlisten] build environment:
2019-11-07T02:10:28.144+0000 I  CONTROL  [initandlisten]     distmod: ubuntu1804
2019-11-07T02:10:28.144+0000 I  CONTROL  [initandlisten]     distarch: x86_64
2019-11-07T02:10:28.144+0000 I  CONTROL  [initandlisten]     target_arch: x86_64
2019-11-07T02:10:28.144+0000 I  CONTROL  [initandlisten] options: { net: { bindIp: "*" } }
2019-11-07T02:10:28.145+0000 I  STORAGE  [initandlisten] 
2019-11-07T02:10:28.145+0000 I  STORAGE  [initandlisten] ** WARNING: Using the XFS filesystem is strongly recommended with the WiredTiger storage engine
2019-11-07T02:10:28.145+0000 I  STORAGE  [initandlisten] **          See http://dochub.mongodb.org/core/prodnotes-filesystem
2019-11-07T02:10:28.145+0000 I  STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=15532M,cache_overflow=(file_max=0M),session_max=33000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),statistics_log=(wait=0),verbose=[recovery_progress,checkpoint_progress],
2019-11-07T02:10:28.863+0000 I  STORAGE  [initandlisten] WiredTiger message [1573092628:863219][29:0x7f067cb39b00], txn-recover: Set global recovery timestamp: (0,0)
2019-11-07T02:10:28.885+0000 I  RECOVERY [initandlisten] WiredTiger recoveryTimestamp. Ts: Timestamp(0, 0)
2019-11-07T02:10:28.901+0000 I  STORAGE  [initandlisten] Timestamp monitor starting
2019-11-07T02:10:28.910+0000 I  CONTROL  [initandlisten] 
2019-11-07T02:10:28.910+0000 I  CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
2019-11-07T02:10:28.910+0000 I  CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
2019-11-07T02:10:28.910+0000 I  CONTROL  [initandlisten] ** WARNING: You are running this process as the root user, which is not recommended.
2019-11-07T02:10:28.910+0000 I  CONTROL  [initandlisten] 
2019-11-07T02:10:28.911+0000 I  STORAGE  [initandlisten] createCollection: admin.system.version with provided UUID: 30a7a70a-d542-4296-923c-9b1981503bf9 and options: { uuid: UUID("30a7a70a-d542-4296-923c-9b1981503bf9") }
2019-11-07T02:10:28.939+0000 I  INDEX    [initandlisten] index build: done building index _id_ on ns admin.system.version
2019-11-07T02:10:28.939+0000 I  SHARDING [initandlisten] Marking collection admin.system.version as collection version: <unsharded>
2019-11-07T02:10:28.939+0000 I  COMMAND  [initandlisten] setting featureCompatibilityVersion to 4.2
2019-11-07T02:10:28.943+0000 I  SHARDING [initandlisten] Marking collection local.system.replset as collection version: <unsharded>
2019-11-07T02:10:28.943+0000 I  STORAGE  [initandlisten] Flow Control is enabled on this deployment.
2019-11-07T02:10:28.943+0000 I  SHARDING [initandlisten] Marking collection admin.system.roles as collection version: <unsharded>
2019-11-07T02:10:28.944+0000 I  STORAGE  [initandlisten] createCollection: local.startup_log with generated UUID: dab13016-119c-4c00-bd3e-51ae1495c6e2 and options: { capped: true, size: 10485760 }
2019-11-07T02:10:28.962+0000 I  INDEX    [initandlisten] index build: done building index _id_ on ns local.startup_log
2019-11-07T02:10:28.962+0000 I  SHARDING [initandlisten] Marking collection local.startup_log as collection version: <unsharded>
2019-11-07T02:10:28.963+0000 I  FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/data/db/diagnostic.data'
2019-11-07T02:10:28.964+0000 I  SHARDING [LogicalSessionCacheRefresh] Marking collection config.system.sessions as collection version: <unsharded>
2019-11-07T02:10:28.964+0000 I  NETWORK  [initandlisten] Listening on /tmp/mongodb-27017.sock
2019-11-07T02:10:28.964+0000 I  NETWORK  [initandlisten] Listening on 0.0.0.0
2019-11-07T02:10:28.964+0000 I  NETWORK  [initandlisten] waiting for connections on port 27017
2019-11-07T02:10:28.964+0000 I  CONTROL  [LogicalSessionCacheReap] Sessions collection is not set up; waiting until next sessions reap interval: config.system.sessions does not exist
2019-11-07T02:10:28.964+0000 I  STORAGE  [LogicalSessionCacheRefresh] createCollection: config.system.sessions with provided UUID: 0e4a91b2-df82-4e10-8831-fcbe2d70e45b and options: { uuid: UUID("0e4a91b2-df82-4e10-8831-fcbe2d70e45b") }
2019-11-07T02:10:28.986+0000 I  INDEX    [LogicalSessionCacheRefresh] index build: done building index _id_ on ns config.system.sessions
2019-11-07T02:10:29.005+0000 I  INDEX    [LogicalSessionCacheRefresh] index build: starting on config.system.sessions properties: { v: 2, key: { lastUse: 1 }, name: "lsidTTLIndex", ns: "config.system.sessions", expireAfterSeconds: 1800 } using method: Hybrid
2019-11-07T02:10:29.005+0000 I  INDEX    [LogicalSessionCacheRefresh] build may temporarily use up to 500 megabytes of RAM
2019-11-07T02:10:29.005+0000 I  INDEX    [LogicalSessionCacheRefresh] index build: collection scan done. scanned 0 total records in 0 seconds
2019-11-07T02:10:29.005+0000 I  INDEX    [LogicalSessionCacheRefresh] index build: inserted 0 keys from external sorter into index in 0 seconds
2019-11-07T02:10:29.009+0000 I  INDEX    [LogicalSessionCacheRefresh] index build: done building index lsidTTLIndex on ns config.system.sessions
level=ERROR ts=2019-11-07T02:10:29.200574667Z app=edgex-mongo source=logger.go:105 msg="logTarget cannot be blank, using stdout only"
2019-11-07T02:10:29.201+0000 I  NETWORK  [listener] connection accepted from 127.0.0.1:51714 #1 (1 connection now open)
2019-11-07T02:10:29.201+0000 I  NETWORK  [conn1] received client metadata from 127.0.0.1:51714 conn1: { driver: { name: "mgo", version: "globalsign" }, os: { architecture: "amd64", type: "linux" } }
level=INFO ts=2019-11-07T02:10:29.202139583Z app=edgex-mongo source=client.go:46 msg="Settting up admin database"
2019-11-07T02:10:29.231+0000 I  SHARDING [conn1] Marking collection admin.system.users as collection version: <unsharded>
2019-11-07T02:10:29.261+0000 I  STORAGE  [conn1] createCollection: admin.system.users with generated UUID: 950b5f36-e8fd-468c-9f9d-47e8d236bb5f and options: {}
2019-11-07T02:10:29.286+0000 I  INDEX    [conn1] index build: done building index _id_ on ns admin.system.users
2019-11-07T02:10:29.301+0000 I  INDEX    [conn1] index build: done building index user_1_db_1 on ns admin.system.users
level=INFO ts=2019-11-07T02:10:29.302890442Z app=edgex-mongo source=client.go:46 msg="Settting up coredata database"
2019-11-07T02:10:29.356+0000 I  STORAGE  [conn1] createCollection: coredata.event with provided UUID: 72144d61-cb98-4ff7-8340-02c17b7568a3 and options: { uuid: UUID("72144d61-cb98-4ff7-8340-02c17b7568a3") }
2019-11-07T02:10:29.380+0000 I  INDEX    [conn1] index build: done building index _id_ on ns coredata.event
```

</details>

Fixes https://github.com/edgexfoundry/developer-scripts/issues/167