### PR TITLE
Upgrade Kong to 1.3.0 for x86

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -144,7 +144,7 @@ services:
         - 'POSTGRES_USER=kong'
 
   kong-migrations:
-    image: "kong:1.0.3"
+    image: "kong:1.3.0"
     container_name: kong-migrations
     networks:
       edgex-network:
@@ -171,7 +171,7 @@ services:
       - consul
 
   kong:
-    image: "kong:1.0.3"
+    image: "kong:1.3.0"
     container_name: kong
     hostname: kong
     networks:


### PR DESCRIPTION
Upgrade Kong docker image to version 1.3.0

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>