### PR TITLE
Fixes the issue #177: add missing vault-config volume for core services in security nightly compose

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -262,6 +262,7 @@ services:
       - log-data:/edgex/logs
       - consul-config:/consul/config
       - consul-data:/consul/data
+      - vault-config:/vault/config
     depends_on:
       - config-seed
       - mongo
@@ -297,6 +298,7 @@ services:
       - log-data:/edgex/logs
       - consul-config:/consul/config
       - consul-data:/consul/data
+      - vault-config:/vault/config
     depends_on:
       - logging
 
@@ -313,6 +315,7 @@ services:
       - log-data:/edgex/logs
       - consul-config:/consul/config
       - consul-data:/consul/data
+      - vault-config:/vault/config
     depends_on:
       - logging
 
@@ -330,6 +333,7 @@ services:
       - log-data:/edgex/logs
       - consul-config:/consul/config
       - consul-data:/consul/data
+      - vault-config:/vault/config
     depends_on:
       - logging
 
@@ -346,6 +350,7 @@ services:
       - log-data:/edgex/logs
       - consul-config:/consul/config
       - consul-data:/consul/data
+      - vault-config:/vault/config
     depends_on:
       - metadata
 
@@ -362,6 +367,7 @@ services:
       - log-data:/edgex/logs
       - consul-config:/consul/config
       - consul-data:/consul/data
+      - vault-config:/vault/config
     depends_on:
       - metadata
 
@@ -414,6 +420,7 @@ services:
   #      - log-data:/edgex/logs
   #      - consul-config:/consul/config
   #      - consul-data:/consul/data
+  #      - vault-config:/vault/config
   #    depends_on:
   #      - data
   #
@@ -431,6 +438,7 @@ services:
   #      - log-data:/edgex/logs
   #      - consul-config:/consul/config
   #      - consul-data:/consul/data
+  #      - vault-config:/vault/config
   #    depends_on:
   #      - export-client
   #    environment:


### PR DESCRIPTION
Fixes #177 

For core services, vault-config volumes are missing.  Add vault-config volume mapping into core-services.

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>