### PR TITLE
Allocate a tty to kong

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -206,6 +206,7 @@ services:
         - "8001:8001"
         - "8443:8443"
         - "8444:8444"
+    tty: true
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -205,6 +205,7 @@ services:
         - "8001:8001"
         - "8443:8443"
         - "8444:8444"
+    tty: true
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'


### PR DESCRIPTION
Fixes https://github.com/edgexfoundry/blackbox-testing/issues/368

This (should) prevent the following error in blackbox testing:
chmod: changing permissions of '/proc/self/fd/1': Permission denied
chmod: changing permissions of '/proc/self/fd/2': Permission denied
nginx: [emerg] open() "/dev/stderr" failed (13: Permission denied)

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>