### PR TITLE
Use security version of docker-edgex-consul for arm64.

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -52,7 +52,7 @@ services:
       - consul-data:/consul/data:z
 
   consul:
-    image: nexus3.edgexfoundry.org:10001/arm64v8/consul:1.3.1
+    image: nexus3.edgexfoundry.org:10004/docker-edgex-consul-arm64:master
     ports:
       - "8400:8400"
       - "8500:8500"


### PR DESCRIPTION
Fixes https://github.com/edgexfoundry/blackbox-testing/issues/369
Addresses https://github.com/edgexfoundry/edgex-go/issues/2171

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>