### PR TITLE
Enable edgex-proxy to use per-service token instead of root token.

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -245,10 +245,9 @@ services:
       - vault-config:/vault/config:z
       - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
-      - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
+      - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
     depends_on:
-        - vault
-        - kong-db
+        - vault-worker
         - kong
 
 # end of containers for reverse proxy

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -244,10 +244,9 @@ services:
       - vault-config:/vault/config:z
       - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
-      - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z      
+      - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
     depends_on:
-        - vault
-        - kong-db
+        - vault-worker
         - kong
 
 # end of containers for reverse proxy


### PR DESCRIPTION
Modifies the secrets volume of edgex-proxy so that it has access
to its per-service token.  Remove the volume mount to the actual
TLS certificate since edgex-proxy gets the TLS cert from the
secret store.  Fix dependency on edgex-proxy (actually depends
on vault-worker to upload the TLS cert, not vault) and
remove kong-db (kong already depends on kong-db).

Address https://github.com/edgexfoundry/edgex-go/issues/1930

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>