### PR TITLE
Fix vault-worker on arm64 security build so that it mounts all secrets volumes

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -144,8 +144,7 @@ services:
     volumes:
       - vault-config:/vault/config:z
       - consul-scripts:/consul/scripts:ro,z
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
-      - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
+      - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     depends_on:
       - volume
       - consul


### PR DESCRIPTION
vault-worker needs to be able to write secrets tokens for
all microservices.

Fixes https://github.com/edgexfoundry/blackbox-testing/issues/381

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>