### PR TITLE
Fix postgres-db initialization requires a password to start now

### DIFF
--- a/releases/fuji/compose-files/docker-compose-fuji.yml
+++ b/releases/fuji/compose-files/docker-compose-fuji.yml
@@ -150,7 +150,7 @@ services:
     environment:
         - 'POSTGRES_DB=kong'
         - 'POSTGRES_USER=kong'
-
+        - 'POSTGRES_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
   kong-migrations:
     image: kong:1.3.0
     container_name: kong-migrations
@@ -161,6 +161,7 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
     command: >
       /bin/sh -cx 
       'until /consul/scripts/consul-svc-healthy.sh kong-db;
@@ -194,6 +195,7 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
         - 'KONG_PROXY_ACCESS_LOG=/dev/stdout'
         - 'KONG_ADMIN_ACCESS_LOG=/dev/stdout'
         - 'KONG_PROXY_ERROR_LOG=/dev/stderr'

--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -166,6 +166,7 @@ services:
     environment:
         - 'POSTGRES_DB=kong'
         - 'POSTGRES_USER=kong'
+        - 'POSTGRES_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
 
   kong-migrations:
     image: kong:1.3.0-ubuntu
@@ -177,6 +178,7 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
     command: >
       /bin/sh -cx 
       'until /consul/scripts/consul-svc-healthy.sh kong-db;
@@ -211,6 +213,7 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
         - 'KONG_PROXY_ACCESS_LOG=/dev/stdout'
         - 'KONG_ADMIN_ACCESS_LOG=/dev/stdout'
         - 'KONG_PROXY_ERROR_LOG=/dev/stderr'

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -166,6 +166,7 @@ services:
     environment:
         - 'POSTGRES_DB=kong'
         - 'POSTGRES_USER=kong'
+        - 'POSTGRES_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
 
   kong-migrations:
     image: kong:1.3.0
@@ -177,6 +178,7 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
     command: >
       /bin/sh -cx 
       'until /consul/scripts/consul-svc-healthy.sh kong-db;
@@ -211,6 +213,7 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
         - 'KONG_PROXY_ACCESS_LOG=/dev/stdout'
         - 'KONG_ADMIN_ACCESS_LOG=/dev/stdout'
         - 'KONG_PROXY_ERROR_LOG=/dev/stderr'


### PR DESCRIPTION
https://github.com/docker-library/postgres/pull/658

Before
```
docker-compose -f docker-compose-nexus.yml ps
      Name                     Command               State                                                           Ports
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
edgex-core-consul   docker-entrypoint.sh agent ...   Up       8300/tcp, 8301/tcp, 8301/udp, 8302/tcp, 8302/udp, 0.0.0.0:8400->8400/tcp, 0.0.0.0:8500->8500/tcp, 8600/tcp, 8600/udp
edgex-files         /bin/sh -c /usr/bin/tail - ...   Up
kong                /docker-entrypoint.sh /bin ...   Up       0.0.0.0:8000->8000/tcp, 0.0.0.0:8001->8001/tcp, 0.0.0.0:8443->8443/tcp, 0.0.0.0:8444->8444/tcp
kong-db             docker-entrypoint.sh postgres    Exit 1
kong-migrations     /docker-entrypoint.sh /bin ...   Up       8000/tcp, 8001/tcp, 8443/tcp, 8444/tcp
(failed reverse-i-search)`kong-db': cd ../^Cng-build-tools/
ubuntu@34:~/projects/edgex/developer-scripts/releases/nightly-build/compose-files$
ubuntu@34:~/projects/edgex/developer-scripts/releases/nightly-build/compose-files$
ubuntu@34:~/projects/edgex/developer-scripts/releases/nightly-build/compose-files$ docker-compose -f docker-compose-nexus.yml logs kong-db
Attaching to kong-db
kong-db                   | Error: Database is uninitialized and superuser password is not specified.
kong-db                   |        You must specify POSTGRES_PASSWORD for the superuser. Use
kong-db                   |        "-e POSTGRES_PASSWORD=password" to set it in "docker run".
kong-db                   |
kong-db                   |        You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
kong-db                   |        without a password. This is *not* recommended. See PostgreSQL
kong-db                   |        documentation about "trust":
kong-db                   |        https://www.postgresql.org/docs/current/auth-trust.html
kong-db                   | Error: Database is uninitialized and superuser password is not specified.
kong-db                   |        You must specify POSTGRES_PASSWORD for the superuser. Use
kong-db                   |        "-e POSTGRES_PASSWORD=password" to set it in "docker run".
kong-db                   |
kong-db                   |        You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
kong-db                   |        without a password. This is *not* recommended. See PostgreSQL
kong-db                   |        documentation about "trust":
kong-db                   |        https://www.postgresql.org/docs/current/auth-trust.html
```

After
```
docker-compose -f docker-compose-nexus.yml ps
      Name                     Command               State                                                           Ports
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
edgex-core-consul   docker-entrypoint.sh agent ...   Up       8300/tcp, 8301/tcp, 8301/udp, 8302/tcp, 8302/udp, 0.0.0.0:8400->8400/tcp, 0.0.0.0:8500->8500/tcp, 8600/tcp, 8600/udp
edgex-files         /bin/sh -c /usr/bin/tail - ...   Up
kong                /docker-entrypoint.sh /bin ...   Up       0.0.0.0:8000->8000/tcp, 0.0.0.0:8001->8001/tcp, 0.0.0.0:8443->8443/tcp, 0.0.0.0:8444->8444/tcp
kong-db             docker-entrypoint.sh postgres    Up       0.0.0.0:5432->5432/tcp
kong-migrations     /docker-entrypoint.sh /bin ...   Exit 0
```

Fixes https://github.com/edgexfoundry/blackbox-testing/issues/389