### PR TITLE
fix[security-services]: Explicitly specify POSTGRES_PASSWORD

### DIFF
--- a/releases/fuji/compose-files/docker-compose-fuji.yml
+++ b/releases/fuji/compose-files/docker-compose-fuji.yml
@@ -150,6 +150,7 @@ services:
     environment:
         - 'POSTGRES_DB=kong'
         - 'POSTGRES_USER=kong'
+        - 'POSTGRES_PASSWORD=changeme'
 
   kong-migrations:
     image: kong:1.3.0
@@ -161,6 +162,8 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_USER=kong'
+        - 'KONG_PG_PASSWORD=changeme'
     command: >
       /bin/sh -cx 
       'until /consul/scripts/consul-svc-healthy.sh kong-db;
@@ -194,6 +197,8 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_USER=kong'
+        - 'KONG_PG_PASSWORD=changeme'
         - 'KONG_PROXY_ACCESS_LOG=/dev/stdout'
         - 'KONG_ADMIN_ACCESS_LOG=/dev/stdout'
         - 'KONG_PROXY_ERROR_LOG=/dev/stderr'

--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -166,6 +166,7 @@ services:
     environment:
         - 'POSTGRES_DB=kong'
         - 'POSTGRES_USER=kong'
+        - 'POSTGRES_PASSWORD=changeme'
 
   kong-migrations:
     image: kong:1.3.0-ubuntu
@@ -177,6 +178,8 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_USER=kong'
+        - 'KONG_PG_PASSWORD=changeme'
     command: >
       /bin/sh -cx 
       'until /consul/scripts/consul-svc-healthy.sh kong-db;
@@ -211,6 +214,8 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_USER=kong'
+        - 'KONG_PG_PASSWORD=changeme'
         - 'KONG_PROXY_ACCESS_LOG=/dev/stdout'
         - 'KONG_ADMIN_ACCESS_LOG=/dev/stdout'
         - 'KONG_PROXY_ERROR_LOG=/dev/stderr'

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -166,6 +166,7 @@ services:
     environment:
         - 'POSTGRES_DB=kong'
         - 'POSTGRES_USER=kong'
+        - 'POSTGRES_PASSWORD=changeme'
 
   kong-migrations:
     image: kong:1.3.0
@@ -177,6 +178,8 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_USER=kong'
+        - 'KONG_PG_PASSWORD=changeme'
     command: >
       /bin/sh -cx 
       'until /consul/scripts/consul-svc-healthy.sh kong-db;
@@ -211,6 +214,8 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_USER=kong'
+        - 'KONG_PG_PASSWORD=changeme'
         - 'KONG_PROXY_ACCESS_LOG=/dev/stdout'
         - 'KONG_ADMIN_ACCESS_LOG=/dev/stdout'
         - 'KONG_PROXY_ERROR_LOG=/dev/stderr'


### PR DESCRIPTION
Broken by upstream container update; Postgres 9.6.17 and later
require POSTGRES_PASSWORD be explicitly set.

Fixes https://github.com/edgexfoundry/blackbox-testing/issues/389

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>