### PR TITLE
fix[security-services]: Address race condition for mongodb initialization

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
@@ -58,6 +58,8 @@ services:
       - "8500:8500"
     container_name: edgex-core-consul
     hostname: edgex-core-consul
+    environment:
+      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
     networks:
       edgex-network:
         aliases:
@@ -66,8 +68,8 @@ services:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
       - consul-scripts:/consul/scripts:z
-      - vault-config:/vault/config:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+      - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
       - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
     depends_on:
@@ -137,6 +139,8 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go-arm64:master
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
+    environment:
+      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
     networks:
       edgex-network:
         aliases:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
@@ -58,6 +58,8 @@ services:
       - "8500:8500"
     container_name: edgex-core-consul
     hostname: edgex-core-consul
+    environment:
+      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
     networks:
       edgex-network:
         aliases:
@@ -66,8 +68,8 @@ services:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
       - consul-scripts:/consul/scripts:z
-      - vault-config:/vault/config:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+      - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
       - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
     depends_on:
@@ -137,6 +139,8 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:master
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
+    environment:
+      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
     networks:
       edgex-network:
         aliases:


### PR DESCRIPTION
Fixes https://github.com/edgexfoundry/edgex-go/issues/2383
Fixes https://github.com/edgexfoundry/docker-edgex-consul/issues/21

This fix addresses a race condition for mongodb initialization
wherein the secret store is set up, but has not generated
per-sevice Vault tokens, nor committed mongodb passwords to
the secret store.  This fix introduces a sentinel file that
is used to indicate secretstore-setup completion without
giving access to the secretstore to an untrusted component (consul).

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>