### PR TITLE
Provide the MongoDB config via env variable

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
@@ -24,6 +24,10 @@ x-common-env-variables: &common-variables
   Clients_CoreData_Host: edgex-core-data
   Clients_Logging_Host: edgex-support-logging
   Logging_EnableRemote: "true"
+  Databases_Primary_Type: mongodb
+  Databases_Primary_Host: edgex-mongo
+  Databases_Primary_Port: 27017
+  support-logging_Writable_Persistence: database
 
 volumes:
   db-data:
@@ -83,6 +87,8 @@ services:
       edgex-network:
         aliases:
             - edgex-core-config-seed
+    environment:
+      <<: *common-variables
     volumes:
       - db-data:/data/db:z
       - log-data:/edgex/logs:z

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
@@ -29,6 +29,10 @@ x-common-env-variables: &common-variables
   Clients_CoreData_Host: edgex-core-data
   Clients_Logging_Host: edgex-support-logging
   Logging_EnableRemote: "true"
+  Databases_Primary_Type: mongodb
+  Databases_Primary_Host: edgex-mongo
+  Databases_Primary_Port: 27017
+  support-logging_Writable_Persistence: database
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
@@ -29,6 +29,10 @@ x-common-env-variables: &common-variables
   Clients_CoreData_Host: edgex-core-data
   Clients_Logging_Host: edgex-support-logging
   Logging_EnableRemote: "true"
+  Databases_Primary_Type: mongodb
+  Databases_Primary_Host: edgex-mongo
+  Databases_Primary_Port: 27017
+  support-logging_Writable_Persistence: database
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
@@ -24,6 +24,10 @@ x-common-env-variables: &common-variables
   Clients_CoreData_Host: edgex-core-data
   Clients_Logging_Host: edgex-support-logging
   Logging_EnableRemote: "true"
+  Databases_Primary_Type: mongodb
+  Databases_Primary_Host: edgex-mongo
+  Databases_Primary_Port: 27017
+  support-logging_Writable_Persistence: database
 
 volumes:
   db-data:
@@ -83,6 +87,8 @@ services:
       edgex-network:
         aliases:
             - edgex-core-config-seed
+    environment:
+      <<: *common-variables
     volumes:
       - db-data:/data/db:z
       - log-data:/edgex/logs:z


### PR DESCRIPTION
edgex-go use the RedisDB as default DB, so docker-compose needs to override the database config to enable the MongoDB
https://github.com/edgexfoundry/edgex-go/blob/master/cmd/support-scheduler/res/docker/configuration.toml#L31

Fix #228 