### PR TITLE
fix: Consul health check runtime config

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
@@ -50,7 +50,7 @@ volumes:
 
 services:
   volume:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-volume-arm64:master
+    image: ubuntu:latest
     container_name: edgex-files
     networks:
       - edgex-network
@@ -59,6 +59,7 @@ services:
       - log-data:/edgex/logs:z
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
+    entrypoint: [ "tail", "-f", "/dev/null" ]
 
   consul:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-consul-arm64:master
@@ -69,6 +70,8 @@ services:
     hostname: edgex-core-consul
     environment:
       - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
+      - EDGEX_DB=mongo
+      - EDGEX_SECURE=true
     networks:
       edgex-network:
         aliases:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
@@ -45,7 +45,7 @@ volumes:
 
 services:
   volume:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-volume-arm64:master
+    image: ubuntu:latest
     container_name: edgex-files
     networks:
       - edgex-network
@@ -58,9 +58,10 @@ services:
       - log-data:/edgex/logs:z
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
+    entrypoint: [ "tail", "-f", "/dev/null" ]
 
   consul:
-    image: nexus3.edgexfoundry.org:10001/arm64v8/consul:1.3.1
+    image: nexus3.edgexfoundry.org:10004/docker-edgex-consul-arm64:master
     ports:
       - "8400:8400"
       - "8500:8500"
@@ -75,6 +76,9 @@ services:
       - consul-data:/consul/data:z
     depends_on:
       - volume
+    environment: 
+      - EDGEX_DB=mongo
+      - EDGEX_SECURE=false
 
   mongo:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-mongo-arm64:master

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
@@ -45,7 +45,7 @@ volumes:
 
 services:
   volume:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-volume:master
+    image: ubuntu:latest
     container_name: edgex-files
     networks:
       - edgex-network
@@ -54,9 +54,10 @@ services:
       - log-data:/edgex/logs:z
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
+    entrypoint: [ "tail", "-f", "/dev/null" ]
 
   consul:
-    image: consul:1.3.1
+    image: nexus3.edgexfoundry.org:10004/docker-edgex-consul:master
     ports:
       - "8400:8400"
       - "8500:8500"
@@ -71,6 +72,9 @@ services:
       - consul-data:/consul/data:z
     depends_on:
       - volume
+    environment: 
+      - EDGEX_DB=mongo
+      - EDGEX_SECURE=false
 
   mongo:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-mongo:master

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
@@ -50,7 +50,7 @@ volumes:
 
 services:
   volume:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-volume:master
+    image: ubuntu:latest
     container_name: edgex-files
     networks:
       - edgex-network
@@ -59,6 +59,7 @@ services:
       - log-data:/edgex/logs:z
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
+    entrypoint: [ "tail", "-f", "/dev/null" ]
 
   consul:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-consul:master
@@ -69,6 +70,8 @@ services:
     hostname: edgex-core-consul
     environment:
       - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
+      - EDGEX_DB=mongo
+      - EDGEX_SECURE=true
     networks:
       edgex-network:
         aliases:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
@@ -43,7 +43,7 @@ volumes:
 
 services:
   volume:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-volume-arm64:master
+    image: ubuntu:latest
     container_name: edgex-files
     networks:
       - edgex-network
@@ -52,9 +52,10 @@ services:
       - log-data:/edgex/logs:z
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
+    entrypoint: [ "tail", "-f", "/dev/null" ]
 
   consul:
-    image: nexus3.edgexfoundry.org:10001/arm64v8/consul:1.3.1
+    image: nexus3.edgexfoundry.org:10004/docker-edgex-consul-arm64:master
     ports:
       - "8400:8400"
       - "8500:8500"
@@ -70,6 +71,9 @@ services:
       - consul-data:/consul/data:z
     depends_on:
       - volume
+    environment: 
+      - EDGEX_DB=redis
+      - EDGEX_SECURE=false
 
   redis:
     image: arm64v8/redis:5.0.7-alpine

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
@@ -43,7 +43,7 @@ volumes:
 
 services:
   volume:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-volume:master
+    image: ubuntu:latest
     container_name: edgex-files
     networks:
       - edgex-network
@@ -52,9 +52,10 @@ services:
       - log-data:/edgex/logs:z
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
+    entrypoint: [ "tail", "-f", "/dev/null" ]
 
   consul:
-    image: consul:1.3.1
+    image: nexus3.edgexfoundry.org:10004/docker-edgex-consul:master
     ports:
       - "8400:8400"
       - "8500:8500"
@@ -70,6 +71,9 @@ services:
       - consul-data:/consul/data:z
     depends_on:
       - volume
+    environment: 
+      - EDGEX_DB=redis
+      - EDGEX_SECURE=false
 
   redis:
     image: redis:5.0.7-alpine


### PR DESCRIPTION
Fixes https://github.com/edgexfoundry/developer-scripts/issues/242
Fixes https://github.com/edgexfoundry/developer-scripts/issues/220
Fixes https://github.com/edgexfoundry/developer-scripts/issues/213

Added the new environment variables to the consul services in each of
the compose files. The vars, EDGEX_DB and EDGEX_SECURE are utilized in
an entrypoint script in the docker-edgex-consul image that initializes
default config and script files based on these environment variables.
These variables are NOT required (as they have defaults if the system
can't find them), however, it is encouraged to use them so that
configuration is explicitly set, and the developers happen to know what
might be going on in the event of a misconfigured consul service.

Signed-off-by: Beau Frusetta <beau.frusetta@intel.com>