### PR TITLE
fix[blackbox]: Override docker host name for edgex-device-virtual

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
@@ -28,6 +28,7 @@ x-common-env-variables: &common-variables
   Clients_Command_Host: edgex-core-command
   Clients_Scheduler_Host: edgex-support-scheduler
   Clients_RulesEngine_Host: edgex-kuiper
+  Clients_VirtualDevice_Host: edgex-device-virtual
   Databases_Primary_Type: mongodb
   Databases_Primary_Host: edgex-mongo
   Databases_Primary_Port: 27017

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
@@ -33,6 +33,7 @@ x-common-env-variables: &common-variables
   Clients_Command_Host: edgex-core-command
   Clients_Scheduler_Host: edgex-support-scheduler
   Clients_RulesEngine_Host: edgex-kuiper
+  Clients_VirtualDevice_Host: edgex-device-virtual
   Databases_Primary_Type: mongodb
   Databases_Primary_Host: edgex-mongo
   Databases_Primary_Port: 27017

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
@@ -33,6 +33,7 @@ x-common-env-variables: &common-variables
   Clients_Command_Host: edgex-core-command
   Clients_Scheduler_Host: edgex-support-scheduler
   Clients_RulesEngine_Host: edgex-kuiper
+  Clients_VirtualDevice_Host: edgex-device-virtual
   Databases_Primary_Type: mongodb
   Databases_Primary_Host: edgex-mongo
   Databases_Primary_Port: 27017

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
@@ -28,6 +28,7 @@ x-common-env-variables: &common-variables
   Clients_Command_Host: edgex-core-command
   Clients_Scheduler_Host: edgex-support-scheduler
   Clients_RulesEngine_Host: edgex-kuiper
+  Clients_VirtualDevice_Host: edgex-device-virtual
   Databases_Primary_Type: mongodb
   Databases_Primary_Host: edgex-mongo
   Databases_Primary_Port: 27017

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
@@ -33,6 +33,7 @@ x-common-env-variables: &common-variables
   Clients_Command_Host: edgex-core-command
   Clients_Scheduler_Host: edgex-support-scheduler
   Clients_RulesEngine_Host: edgex-kuiper
+  Clients_VirtualDevice_Host: edgex-device-virtual
   Databases_Primary_Host: edgex-redis
 
 volumes:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
@@ -33,6 +33,7 @@ x-common-env-variables: &common-variables
   Clients_Command_Host: edgex-core-command
   Clients_Scheduler_Host: edgex-support-scheduler
   Clients_RulesEngine_Host: edgex-kuiper
+  Clients_VirtualDevice_Host: edgex-device-virtual
   Databases_Primary_Host: edgex-redis
 
 volumes:


### PR DESCRIPTION
Fixes miss for Clients.VirtualDevice in https://github.com/edgexfoundry/edgex-go/blob/master/cmd/security-proxy-setup/res/configuration.toml

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>