### PR TITLE
refact(portainer): refactor compose files to move Portainer to its own file.

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
@@ -46,7 +46,6 @@ volumes:
   vault-file:
   vault-logs:
   # non-shared volumes
-  portainer_data:
   secrets-setup-cache:
 
 services:
@@ -567,21 +566,6 @@ services:
     depends_on:
       - data
       - command
-
-#################################################################
-# Tooling
-#################################################################
-
-  portainer:
-    image:  portainer/portainer
-    ports:
-      - "9000:9000"
-    command: -H unix:///var/run/docker.sock
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:z
-      - portainer_data:/data
-    depends_on:
-      - volume
 
 networks:
   edgex-network:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
@@ -42,7 +42,6 @@ volumes:
   log-data:
   consul-config:
   consul-data:
-  portainer_data:
 
 services:
   volume:
@@ -375,21 +374,6 @@ services:
     depends_on:
       - data
       - command
-
-#################################################################
-# Tooling
-#################################################################
-
-  portainer:
-    image:  portainer/portainer
-    ports:
-      - "9000:9000"
-    command: -H unix:///var/run/docker.sock
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:z
-      - portainer_data:/data
-    depends_on:
-      - volume
 
 networks:
   edgex-network:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
@@ -42,7 +42,6 @@ volumes:
   log-data:
   consul-config:
   consul-data:
-  portainer_data:
 
 services:
   volume:
@@ -371,21 +370,6 @@ services:
     depends_on:
       - data
       - command
-
-#################################################################
-# Tooling
-#################################################################
-
-  portainer:
-    image:  portainer/portainer
-    ports:
-      - "9000:9000"
-    command: -H unix:///var/run/docker.sock
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:z
-      - portainer_data:/data
-    depends_on:
-      - volume
 
 networks:
   edgex-network:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
@@ -46,7 +46,6 @@ volumes:
   vault-file:
   vault-logs:
   # non-shared volumes
-  portainer_data:
   secrets-setup-cache:
 
 services:
@@ -567,21 +566,6 @@ services:
     depends_on:
       - data
       - command
-
-#################################################################
-# Tooling
-#################################################################
-
-  portainer:
-    image:  portainer/portainer
-    ports:
-      - "9000:9000"
-    command: -H unix:///var/run/docker.sock
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:z
-      - portainer_data:/data
-    depends_on:
-      - volume
 
 networks:
   edgex-network:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
@@ -40,7 +40,6 @@ volumes:
   log-data:
   consul-config:
   consul-data:
-  portainer_data:
 
 services:
   volume:
@@ -358,21 +357,6 @@ services:
     depends_on:
       - data
       - command
-
-#################################################################
-# Tooling
-#################################################################
-
-  portainer:
-    image:  portainer/portainer
-    ports:
-      - "9000:9000"
-    command: -H unix:///var/run/docker.sock
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:z
-      - portainer_data:/data
-    depends_on:
-      - volume
 
 networks:
   edgex-network:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
@@ -40,7 +40,6 @@ volumes:
   log-data:
   consul-config:
   consul-data:
-  portainer_data:
 
 services:
   volume:
@@ -356,21 +355,6 @@ services:
     depends_on:
       - data
       - command
-
-#################################################################
-# Tooling
-#################################################################
-
-  portainer:
-    image:  portainer/portainer
-    ports:
-      - "9000:9000"
-    command: -H unix:///var/run/docker.sock
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:z
-      - portainer_data:/data
-    depends_on:
-      - volume
 
 networks:
   edgex-network:

--- a/releases/nightly-build/compose-files/docker-compose-portainer.yml
+++ b/releases/nightly-build/compose-files/docker-compose-portainer.yml
@@ -1,0 +1,34 @@
+# /*******************************************************************************
+#  * Copyright 2020 Intel Corporation.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License. You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software distributed under the License
+#  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  * or implied. See the License for the specific language governing permissions and limitations under
+#  * the License.
+#  *
+#  * @authormaster
+#  * EdgeX Foundry, Fuji, version master
+#  * added: Jun 30, 2019
+#  *******************************************************************************/
+
+version: '3.4'
+
+volumes:
+  portainer_data:
+
+services:
+  portainer:
+    image:  portainer/portainer
+    ports:
+      - "9000:9000"
+    container_name: portainer
+    command: -H unix:///var/run/docker.sock
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:z
+      - portainer_data:/data
+


### PR DESCRIPTION
Portianer now can be started and stopped separately from all the other services. It will no longer be stopped when the other services are brought down.