### PR TITLE
cleanup: Remove edgex-volume and correct service dependencies

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
@@ -50,18 +50,6 @@ volumes:
   secrets-setup-cache:
 
 services:
-  volume:
-    image: ubuntu:latest
-    container_name: edgex-files
-    networks:
-      - edgex-network
-    volumes:
-      - db-data:/data/db:z
-      - log-data:/edgex/logs:z
-      - consul-config:/consul/config:z
-      - consul-data:/consul/data:z
-    entrypoint: [ "tail", "-f", "/dev/null" ]
-
   consul:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-consul-arm64:master
     ports:
@@ -69,10 +57,6 @@ services:
       - "8500:8500"
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    environment:
-      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
-      - EDGEX_DB=mongo
-      - EDGEX_SECURE=true
     networks:
       edgex-network:
         aliases:
@@ -85,8 +69,12 @@ services:
       - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
       - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
+    environment:
+      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
+      - EDGEX_DB=mongo
+      - EDGEX_SECURE=true
     depends_on:
-      - volume
+      - security-secrets-setup
 
   vault:
     image: vault:1.3.1
@@ -113,8 +101,8 @@ services:
       - vault-init:/vault/init:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
     depends_on:
-      - security-secrets-setup
       - consul
+      - security-secrets-setup
 
   security-secrets-setup:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-secrets-setup-go-arm64:master
@@ -128,8 +116,6 @@ services:
       - secrets-setup-cache:/etc/edgex/pki
       - vault-init:/vault/init:z
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    depends_on:
-      - volume
 
   vault-worker:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go-arm64:master
@@ -148,7 +134,7 @@ services:
       - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     depends_on:
-      - volume
+      - security-secrets-setup
       - consul
       - vault
 
@@ -167,6 +153,8 @@ services:
         - 'POSTGRES_DB=kong'
         - 'POSTGRES_USER=kong'
         - 'POSTGRES_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
+    depends_on:
+      - security-secrets-setup
 
   kong-migrations:
     image: kong:${KONG_VERSION:-2.0.1}-ubuntu
@@ -192,9 +180,8 @@ services:
     volumes:
       - consul-scripts:/consul/scripts:ro,z
     depends_on:
-      - kong-db
-      - volume
       - consul
+      - kong-db
 
   kong:
     image: kong:${KONG_VERSION:-2.0.1}-ubuntu
@@ -227,10 +214,9 @@ services:
     volumes:
       - consul-scripts:/consul/scripts:ro,z
     depends_on:
-        - kong-db
-        - kong-migrations
-        - volume
-        - consul
+      - consul
+      - kong-db
+      - kong-migrations
 
   edgex-proxy:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go-arm64:master
@@ -257,8 +243,9 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
     depends_on:
-        - vault-worker
-        - kong
+      - consul
+      - vault-worker
+      - kong
 
 # end of containers for reverse proxy
 
@@ -274,12 +261,15 @@ services:
       /edgex-mongo/bin/edgex-mongo-launch.sh"
     networks:
       - edgex-network
+    environment:
+      <<: *common-variables
     volumes:
+      - db-data:/data/db:z
       - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-mongo:/tmp/edgex/secrets/edgex-mongo:ro,z
     depends_on:
-      - volume
+      - consul
       - vault-worker
 
   logging:
@@ -301,7 +291,8 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
     depends_on:
-      - volume
+      - consul
+      - vault-worker
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go-arm64:master
@@ -319,7 +310,13 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
+      - consul
       - logging
+      - scheduler
+      - notifications
+      - metadata
+      - data
+      - command
 
   notifications:
     image: nexus3.edgexfoundry.org:10004/docker-support-notifications-go-arm64:master
@@ -337,7 +334,10 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
     depends_on:
+      - consul
       - logging
+      - mongo
+      - vault-worker
 
   metadata:
     image: nexus3.edgexfoundry.org:10004/docker-core-metadata-go-arm64:master
@@ -356,7 +356,11 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
     depends_on:
+      - consul
       - logging
+      - mongo
+      - notifications
+      - vault-worker
 
   data:
     image: nexus3.edgexfoundry.org:10004/docker-core-data-go-arm64:master
@@ -375,7 +379,11 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
     depends_on:
+      - consul
       - logging
+      - mongo
+      - metadata
+      - vault-worker
 
   command:
     image: nexus3.edgexfoundry.org:10004/docker-core-command-go-arm64:master
@@ -393,7 +401,11 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
     depends_on:
+      - consul
+      - logging
+      - mongo
       - metadata
+      - vault-worker
 
   scheduler:
     image: nexus3.edgexfoundry.org:10004/docker-support-scheduler-go-arm64:master
@@ -413,16 +425,19 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
     depends_on:
-      - metadata
+      - consul
+      - logging
+      - mongo
+      - vault-worker
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
+    entrypoint: ["/app-service-configurable"]
+    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     networks:
       edgex-network:
         aliases:
@@ -440,6 +455,7 @@ services:
       - consul
       - logging
       - data
+      - vault-worker
 
   rulesengine:
     image: emqx/kuiper:0.3.2
@@ -495,8 +511,10 @@ services:
       <<: *common-variables
       Service_Host: edgex-device-virtual
     depends_on:
-    - data
-    - command
+      - consul
+      - logging
+      - data
+      - metadata
 
   # device-random:
   #   image: nexus3.edgexfoundry.org:10004/docker-device-random-go-arm64:master

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
@@ -45,22 +45,6 @@ volumes:
   consul-data:
 
 services:
-  volume:
-    image: ubuntu:latest
-    container_name: edgex-files
-    networks:
-      - edgex-network
-    environment:
-      <<: *common-variables
-      Service_Host: edgex-support-logging
-      Writable_Persistence: database
-    volumes:
-      - db-data:/data/db:z
-      - log-data:/edgex/logs:z
-      - consul-config:/consul/config:z
-      - consul-data:/consul/data:z
-    entrypoint: [ "tail", "-f", "/dev/null" ]
-
   consul:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-consul-arm64:master
     ports:
@@ -75,8 +59,6 @@ services:
     volumes:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
-    depends_on:
-      - volume
     environment: 
       - EDGEX_DB=mongo
       - EDGEX_SECURE=false
@@ -93,8 +75,6 @@ services:
       <<: *common-variables
     volumes:
       - db-data:/data/db:z
-    depends_on:
-      - volume
 
   logging:
     image: nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:master
@@ -111,7 +91,7 @@ services:
       Databases_Primary_Type: file
       Logging_EnableRemote: "false"
     depends_on:
-      - volume
+      - consul
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go-arm64:master
@@ -129,7 +109,13 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
+      - consul
       - logging
+      - scheduler
+      - notifications
+      - metadata
+      - data
+      - command
 
   notifications:
     image: nexus3.edgexfoundry.org:10004/docker-support-notifications-go-arm64:master
@@ -146,7 +132,9 @@ services:
       Databases_Primary_Password: 'password'
       Databases_Primary_Username: 'notifications'
     depends_on:
+      - consul
       - logging
+      - mongo
 
   metadata:
     image: nexus3.edgexfoundry.org:10004/docker-core-metadata-go-arm64:master
@@ -164,7 +152,10 @@ services:
       Databases_Primary_Password: 'password'
       Databases_Primary_Username: 'meta'
     depends_on:
+      - consul
       - logging
+      - mongo
+      - notifications
 
   data:
     image: nexus3.edgexfoundry.org:10004/docker-core-data-go-arm64:master
@@ -182,7 +173,10 @@ services:
       Databases_Primary_Password: 'password'
       Databases_Primary_Username: 'core'
     depends_on:
+      - consul
       - logging
+      - mongo
+      - metadata
 
   command:
     image: nexus3.edgexfoundry.org:10004/docker-core-command-go-arm64:master
@@ -199,6 +193,9 @@ services:
       Databases_Primary_Password: 'password'
       Databases_Primary_Username: 'meta'
     depends_on:
+      - consul
+      - logging
+      - mongo
       - metadata
 
   scheduler:
@@ -218,7 +215,9 @@ services:
       Databases_Primary_Password: 'password'
       Databases_Primary_Username: 'scheduler'
     depends_on:
-      - metadata
+      - consul
+      - logging
+      - mongo
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
@@ -244,7 +243,7 @@ services:
       - consul
       - logging
       - data
-      
+
   rulesengine:
     image: emqx/kuiper:0.3.2
     ports:
@@ -299,8 +298,10 @@ services:
       <<: *common-variables
       Service_Host: edgex-device-virtual
     depends_on:
-    - data
-    - command
+      - consul
+      - logging
+      - data
+      - metadata
 
   # device-random:
   #   image: nexus3.edgexfoundry.org:10004/docker-device-random-go-arm64:master

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
@@ -45,18 +45,6 @@ volumes:
   consul-data:
 
 services:
-  volume:
-    image: ubuntu:latest
-    container_name: edgex-files
-    networks:
-      - edgex-network
-    volumes:
-      - db-data:/data/db:z
-      - log-data:/edgex/logs:z
-      - consul-config:/consul/config:z
-      - consul-data:/consul/data:z
-    entrypoint: [ "tail", "-f", "/dev/null" ]
-
   consul:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-consul:master
     ports:
@@ -71,8 +59,6 @@ services:
     volumes:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
-    depends_on:
-      - volume
     environment: 
       - EDGEX_DB=mongo
       - EDGEX_SECURE=false
@@ -89,8 +75,6 @@ services:
       <<: *common-variables
     volumes:
       - db-data:/data/db:z
-    depends_on:
-      - volume
 
   logging:
     image: nexus3.edgexfoundry.org:10004/docker-support-logging-go:master
@@ -107,7 +91,7 @@ services:
       Databases_Primary_Type: file
       Logging_EnableRemote: "false"
     depends_on:
-      - volume
+      - consul
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:master
@@ -125,7 +109,13 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
+      - consul
       - logging
+      - scheduler
+      - notifications
+      - metadata
+      - data
+      - command
 
   notifications:
     image: nexus3.edgexfoundry.org:10004/docker-support-notifications-go:master
@@ -142,7 +132,9 @@ services:
       Databases_Primary_Password: 'password'
       Databases_Primary_Username: 'notifications'
     depends_on:
+      - consul
       - logging
+      - mongo
 
   metadata:
     image: nexus3.edgexfoundry.org:10004/docker-core-metadata-go:master
@@ -160,7 +152,10 @@ services:
       Databases_Primary_Password: 'password'
       Databases_Primary_Username: 'meta'
     depends_on:
+      - consul
       - logging
+      - mongo
+      - notifications
 
   data:
     image: nexus3.edgexfoundry.org:10004/docker-core-data-go:master
@@ -178,7 +173,10 @@ services:
       Databases_Primary_Password: 'password'
       Databases_Primary_Username: 'core'
     depends_on:
+      - consul
       - logging
+      - mongo
+      - metadata
 
   command:
     image: nexus3.edgexfoundry.org:10004/docker-core-command-go:master
@@ -195,6 +193,9 @@ services:
       Databases_Primary_Password: 'password'
       Databases_Primary_Username: 'meta'
     depends_on:
+      - consul
+      - logging
+      - mongo
       - metadata
 
   scheduler:
@@ -214,16 +215,18 @@ services:
       Databases_Primary_Password: 'password'
       Databases_Primary_Username: 'scheduler'
     depends_on:
-      - metadata
+      - consul
+      - logging
+      - mongo
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
+    entrypoint: ["/app-service-configurable"]
+    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     networks:
       edgex-network:
         aliases:
@@ -240,7 +243,7 @@ services:
       - consul
       - logging
       - data
-      
+
   rulesengine:
     image: emqx/kuiper:0.3.2
     ports:
@@ -295,8 +298,10 @@ services:
       <<: *common-variables
       Service_Host: edgex-device-virtual
     depends_on:
-    - data
-    - command
+      - consul
+      - logging
+      - data
+      - metadata
 
   # device-random:
   #   image: nexus3.edgexfoundry.org:10004/docker-device-random-go:master

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
@@ -50,18 +50,6 @@ volumes:
   secrets-setup-cache:
 
 services:
-  volume:
-    image: ubuntu:latest
-    container_name: edgex-files
-    networks:
-      - edgex-network
-    volumes:
-      - db-data:/data/db:z
-      - log-data:/edgex/logs:z
-      - consul-config:/consul/config:z
-      - consul-data:/consul/data:z
-    entrypoint: [ "tail", "-f", "/dev/null" ]
-
   consul:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-consul:master
     ports:
@@ -69,10 +57,6 @@ services:
       - "8500:8500"
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    environment:
-      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
-      - EDGEX_DB=mongo
-      - EDGEX_SECURE=true
     networks:
       edgex-network:
         aliases:
@@ -85,8 +69,12 @@ services:
       - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
       - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
+    environment:
+      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
+      - EDGEX_DB=mongo
+      - EDGEX_SECURE=true
     depends_on:
-      - volume
+      - security-secrets-setup
 
   vault:
     image: vault:1.3.1
@@ -113,8 +101,8 @@ services:
       - vault-init:/vault/init:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
     depends_on:
-      - security-secrets-setup
       - consul
+      - security-secrets-setup
 
   security-secrets-setup:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-secrets-setup-go:master
@@ -128,8 +116,6 @@ services:
       - secrets-setup-cache:/etc/edgex/pki
       - vault-init:/vault/init:z
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    depends_on:
-      - volume
 
   vault-worker:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:master
@@ -148,7 +134,7 @@ services:
       - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     depends_on:
-      - volume
+      - security-secrets-setup
       - consul
       - vault
 
@@ -167,6 +153,8 @@ services:
         - 'POSTGRES_DB=kong'
         - 'POSTGRES_USER=kong'
         - 'POSTGRES_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
+    depends_on:
+      - security-secrets-setup
 
   kong-migrations:
     image: kong:${KONG_VERSION:-2.0.1}
@@ -192,9 +180,8 @@ services:
     volumes:
       - consul-scripts:/consul/scripts:ro,z
     depends_on:
-      - kong-db
-      - volume
       - consul
+      - kong-db
 
   kong:
     image: kong:${KONG_VERSION:-2.0.1}
@@ -227,10 +214,9 @@ services:
     volumes:
       - consul-scripts:/consul/scripts:ro,z
     depends_on:
-        - kong-db
-        - kong-migrations
-        - volume
-        - consul
+      - consul
+      - kong-db
+      - kong-migrations
 
   edgex-proxy:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:master
@@ -257,8 +243,9 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
     depends_on:
-        - vault-worker
-        - kong
+      - consul
+      - vault-worker
+      - kong
 
 # end of containers for reverse proxy
 
@@ -274,12 +261,15 @@ services:
       /edgex-mongo/bin/edgex-mongo-launch.sh"
     networks:
       - edgex-network
+    environment:
+      <<: *common-variables
     volumes:
+      - db-data:/data/db:z
       - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-mongo:/tmp/edgex/secrets/edgex-mongo:ro,z
     depends_on:
-      - volume
+      - consul
       - vault-worker
 
   logging:
@@ -301,7 +291,8 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
     depends_on:
-      - volume
+      - consul
+      - vault-worker
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:master
@@ -319,7 +310,13 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
+      - consul
       - logging
+      - scheduler
+      - notifications
+      - metadata
+      - data
+      - command
 
   notifications:
     image: nexus3.edgexfoundry.org:10004/docker-support-notifications-go:master
@@ -337,7 +334,10 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
     depends_on:
+      - consul
       - logging
+      - mongo
+      - vault-worker
 
   metadata:
     image: nexus3.edgexfoundry.org:10004/docker-core-metadata-go:master
@@ -356,7 +356,11 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
     depends_on:
+      - consul
       - logging
+      - mongo
+      - notifications
+      - vault-worker
 
   data:
     image: nexus3.edgexfoundry.org:10004/docker-core-data-go:master
@@ -375,7 +379,11 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
     depends_on:
+      - consul
       - logging
+      - mongo
+      - metadata
+      - vault-worker
 
   command:
     image: nexus3.edgexfoundry.org:10004/docker-core-command-go:master
@@ -393,7 +401,11 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
     depends_on:
+      - consul
+      - logging
+      - mongo
       - metadata
+      - vault-worker
 
   scheduler:
     image: nexus3.edgexfoundry.org:10004/docker-support-scheduler-go:master
@@ -413,16 +425,19 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
     depends_on:
-      - metadata
+      - consul
+      - logging
+      - mongo
+      - vault-worker
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
+    entrypoint: ["/app-service-configurable"]
+    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     networks:
       edgex-network:
         aliases:
@@ -440,6 +455,7 @@ services:
       - consul
       - logging
       - data
+      - vault-worker
 
   rulesengine:
     image: emqx/kuiper:0.3.2
@@ -495,8 +511,10 @@ services:
       <<: *common-variables
       Service_Host: edgex-device-virtual
     depends_on:
-    - data
-    - command
+      - consul
+      - logging
+      - data
+      - metadata
 
   # device-random:
   #   image: nexus3.edgexfoundry.org:10004/docker-device-random-go:master

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-arm64.yml
@@ -55,18 +55,6 @@ volumes:
   secrets-setup-cache:
 
 services:
-  volume:
-    image: ubuntu:latest
-    container_name: edgex-files
-    networks:
-      - edgex-network
-    volumes:
-      - db-data:/data:z
-      - log-data:/edgex/logs:z
-      - consul-config:/consul/config:z
-      - consul-data:/consul/data:z
-    entrypoint: [ "tail", "-f", "/dev/null" ]
-
   consul:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-consul-arm64:master
     ports:
@@ -74,10 +62,6 @@ services:
       - "8500:8500"
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    environment:
-      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
-      - EDGEX_DB=redis
-      - EDGEX_SECURE=true
     networks:
       edgex-network:
         aliases:
@@ -90,8 +74,12 @@ services:
       - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
       - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
+    environment:
+      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
+      - EDGEX_DB=redis
+      - EDGEX_SECURE=true
     depends_on:
-      - volume
+      - security-secrets-setup
 
   vault:
     image: vault:1.3.1
@@ -118,8 +106,8 @@ services:
       - vault-init:/vault/init:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
     depends_on:
-      - security-secrets-setup
       - consul
+      - security-secrets-setup
 
   security-secrets-setup:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-secrets-setup-go-arm64:master
@@ -133,8 +121,6 @@ services:
       - secrets-setup-cache:/etc/edgex/pki
       - vault-init:/vault/init:z
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    depends_on:
-      - volume
 
   vault-worker:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go-arm64:master
@@ -154,7 +140,7 @@ services:
       - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     depends_on:
-      - volume
+      - security-secrets-setup
       - consul
       - vault
 
@@ -173,6 +159,8 @@ services:
         - 'POSTGRES_DB=kong'
         - 'POSTGRES_USER=kong'
         - 'POSTGRES_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
+    depends_on:
+      - security-secrets-setup
 
   kong-migrations:
     image: kong:${KONG_VERSION:-2.0.1}-ubuntu
@@ -198,9 +186,8 @@ services:
     volumes:
       - consul-scripts:/consul/scripts:ro,z
     depends_on:
-      - kong-db
-      - volume
       - consul
+      - kong-db
 
   kong:
     image: kong:${KONG_VERSION:-2.0.1}-ubuntu
@@ -233,10 +220,9 @@ services:
     volumes:
       - consul-scripts:/consul/scripts:ro,z
     depends_on:
-        - kong-db
-        - kong-migrations
-        - volume
-        - consul
+      - consul
+      - kong-db
+      - kong-migrations
 
   edgex-proxy:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go-arm64:master
@@ -263,8 +249,9 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
     depends_on:
-        - vault-worker
-        - kong
+      - consul
+      - vault-worker
+      - kong
 
 # end of containers for reverse proxy
 
@@ -291,7 +278,6 @@ services:
       - db-data:/data:z
       - /tmp/edgex/secrets/edgex-redis:/tmp/edgex/secrets/edgex-redis:z
     depends_on:
-      - volume
       - vault-worker
 
   logging:
@@ -313,7 +299,8 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
     depends_on:
-      - volume
+      - consul
+      - vault-worker
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go-arm64:master
@@ -331,7 +318,13 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
+      - consul
       - logging
+      - scheduler
+      - notifications
+      - metadata
+      - data
+      - command
 
   notifications:
     image: nexus3.edgexfoundry.org:10004/docker-support-notifications-go-arm64:master
@@ -349,7 +342,10 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
     depends_on:
+      - consul
       - logging
+      - redis
+      - vault-worker
 
   metadata:
     image: nexus3.edgexfoundry.org:10004/docker-core-metadata-go-arm64:master
@@ -368,7 +364,11 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
     depends_on:
+      - consul
       - logging
+      - redis
+      - notifications
+      - vault-worker
 
   data:
     image: nexus3.edgexfoundry.org:10004/docker-core-data-go-arm64:master
@@ -387,7 +387,11 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
     depends_on:
+      - consul
       - logging
+      - redis
+      - metadata
+      - vault-worker
 
   command:
     image: nexus3.edgexfoundry.org:10004/docker-core-command-go-arm64:master
@@ -405,7 +409,11 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
     depends_on:
+      - consul
+      - logging
+      - redis
       - metadata
+      - vault-worker
 
   scheduler:
     image: nexus3.edgexfoundry.org:10004/docker-support-scheduler-go-arm64:master
@@ -425,16 +433,19 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
     depends_on:
-      - metadata
+      - consul
+      - logging
+      - redis
+      - vault-worker
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
+    entrypoint: ["/app-service-configurable"]
+    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     networks:
       edgex-network:
         aliases:
@@ -452,6 +463,7 @@ services:
       - consul
       - logging
       - data
+      - vault-worker
 
   rulesengine:
     image: emqx/kuiper:0.3.2
@@ -507,8 +519,10 @@ services:
       <<: *common-variables
       Service_Host: edgex-device-virtual
     depends_on:
-    - data
-    - command
+      - consul
+      - logging
+      - data
+      - metadata
 
   # device-random:
   #   image: nexus3.edgexfoundry.org:10004/docker-device-random-go-arm64:master

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
@@ -43,18 +43,6 @@ volumes:
   consul-data:
 
 services:
-  volume:
-    image: ubuntu:latest
-    container_name: edgex-files
-    networks:
-      - edgex-network
-    volumes:
-      - db-data:/data:z
-      - log-data:/edgex/logs:z
-      - consul-config:/consul/config:z
-      - consul-data:/consul/data:z
-    entrypoint: [ "tail", "-f", "/dev/null" ]
-
   consul:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-consul-arm64:master
     ports:
@@ -67,11 +55,8 @@ services:
         aliases:
             - edgex-core-consul
     volumes:
-      - log-data:/edgex/logs:z
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
-    depends_on:
-      - volume
     environment: 
       - EDGEX_DB=redis
       - EDGEX_SECURE=false
@@ -88,8 +73,6 @@ services:
       <<: *common-variables
     volumes:
       - db-data:/data:z
-    depends_on:
-      - volume
 
   logging:
     image: nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:master
@@ -106,7 +89,7 @@ services:
       Databases_Primary_Type: file
       Logging_EnableRemote: "false"
     depends_on:
-      - volume
+      - consul
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go-arm64:master
@@ -124,7 +107,13 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
+      - consul
       - logging
+      - scheduler
+      - notifications
+      - metadata
+      - data
+      - command
 
   notifications:
     image: nexus3.edgexfoundry.org:10004/docker-support-notifications-go-arm64:master
@@ -138,6 +127,7 @@ services:
       <<: *common-variables
       Service_Host: edgex-support-notifications
     depends_on:
+      - consul
       - logging
       - redis
 
@@ -154,8 +144,10 @@ services:
       Service_Host: edgex-core-metadata
       Notifications_Sender: edgex-core-metadata
     depends_on:
+      - consul
       - logging
       - redis
+      - notifications
 
   data:
     image: nexus3.edgexfoundry.org:10004/docker-core-data-go-arm64:master
@@ -170,8 +162,10 @@ services:
       <<: *common-variables
       Service_Host: edgex-core-data
     depends_on:
+      - consul
       - logging
       - redis
+      - metadata
 
   command:
     image: nexus3.edgexfoundry.org:10004/docker-core-command-go-arm64:master
@@ -185,6 +179,9 @@ services:
       <<: *common-variables
       Service_Host: edgex-core-command
     depends_on:
+      - consul
+      - logging
+      - redis
       - metadata
 
   scheduler:
@@ -201,17 +198,18 @@ services:
       IntervalActions_ScrubPushed_Host: edgex-core-data
       IntervalActions_ScrubAged_Host: edgex-core-data
     depends_on:
-      - metadata
+      - consul
+      - logging
       - redis
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
+    entrypoint: ["/app-service-configurable"]
+    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     networks:
       edgex-network:
         aliases:
@@ -283,8 +281,10 @@ services:
       <<: *common-variables
       Service_Host: edgex-device-virtual
     depends_on:
-    - data
-    - command
+      - consul
+      - logging
+      - data
+      - metadata
 
   # device-random:
   #   image: nexus3.edgexfoundry.org:10004/docker-device-random-go-arm64:master

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
@@ -43,18 +43,6 @@ volumes:
   consul-data:
 
 services:
-  volume:
-    image: ubuntu:latest
-    container_name: edgex-files
-    networks:
-      - edgex-network
-    volumes:
-      - db-data:/data:z
-      - log-data:/edgex/logs:z
-      - consul-config:/consul/config:z
-      - consul-data:/consul/data:z
-    entrypoint: [ "tail", "-f", "/dev/null" ]
-
   consul:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-consul:master
     ports:
@@ -67,11 +55,8 @@ services:
         aliases:
             - edgex-core-consul
     volumes:
-      - log-data:/edgex/logs:z
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
-    depends_on:
-      - volume
     environment: 
       - EDGEX_DB=redis
       - EDGEX_SECURE=false
@@ -84,10 +69,10 @@ services:
     hostname: edgex-redis
     networks:
       - edgex-network
+    environment:
+      <<: *common-variables
     volumes:
       - db-data:/data:z
-    depends_on:
-      - volume
 
   logging:
     image: nexus3.edgexfoundry.org:10004/docker-support-logging-go:master
@@ -104,7 +89,7 @@ services:
       Databases_Primary_Type: file
       Logging_EnableRemote: "false"
     depends_on:
-      - volume
+      - consul
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:master
@@ -122,7 +107,13 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
+      - consul
       - logging
+      - scheduler
+      - notifications
+      - metadata
+      - data
+      - command
 
   notifications:
     image: nexus3.edgexfoundry.org:10004/docker-support-notifications-go:master
@@ -136,6 +127,7 @@ services:
       <<: *common-variables
       Service_Host: edgex-support-notifications
     depends_on:
+      - consul
       - logging
       - redis
 
@@ -152,8 +144,10 @@ services:
       Service_Host: edgex-core-metadata
       Notifications_Sender: edgex-core-metadata
     depends_on:
+      - consul
       - logging
       - redis
+      - notifications
 
   data:
     image: nexus3.edgexfoundry.org:10004/docker-core-data-go:master
@@ -168,8 +162,10 @@ services:
       <<: *common-variables
       Service_Host: edgex-core-data
     depends_on:
+      - consul
       - logging
       - redis
+      - metadata
 
   command:
     image: nexus3.edgexfoundry.org:10004/docker-core-command-go:master
@@ -183,6 +179,9 @@ services:
       <<: *common-variables
       Service_Host: edgex-core-command
     depends_on:
+      - consul
+      - logging
+      - redis
       - metadata
 
   scheduler:
@@ -199,17 +198,18 @@ services:
       IntervalActions_ScrubPushed_Host: edgex-core-data
       IntervalActions_ScrubAged_Host: edgex-core-data
     depends_on:
-      - metadata
+      - consul
+      - logging
       - redis
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
+    entrypoint: ["/app-service-configurable"]
+    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     networks:
       edgex-network:
         aliases:
@@ -281,8 +281,10 @@ services:
       <<: *common-variables
       Service_Host: edgex-device-virtual
     depends_on:
-    - data
-    - command
+      - consul
+      - logging
+      - data
+      - metadata
 
   # device-random:
   #   image: nexus3.edgexfoundry.org:10004/docker-device-random-go:master

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis.yml
@@ -55,18 +55,6 @@ volumes:
   secrets-setup-cache:
 
 services:
-  volume:
-    image: ubuntu:latest
-    container_name: edgex-files
-    networks:
-      - edgex-network
-    volumes:
-      - db-data:/data:z
-      - log-data:/edgex/logs:z
-      - consul-config:/consul/config:z
-      - consul-data:/consul/data:z
-    entrypoint: [ "tail", "-f", "/dev/null" ]
-
   consul:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-consul:master
     ports:
@@ -74,10 +62,6 @@ services:
       - "8500:8500"
     container_name: edgex-core-consul
     hostname: edgex-core-consul
-    environment:
-      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
-      - EDGEX_DB=redis
-      - EDGEX_SECURE=true
     networks:
       edgex-network:
         aliases:
@@ -90,8 +74,12 @@ services:
       - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
       - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
+    environment:
+      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
+      - EDGEX_DB=redis
+      - EDGEX_SECURE=true
     depends_on:
-      - volume
+      - security-secrets-setup
 
   vault:
     image: vault:1.3.1
@@ -118,8 +106,8 @@ services:
       - vault-init:/vault/init:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
     depends_on:
-      - security-secrets-setup
       - consul
+      - security-secrets-setup
 
   security-secrets-setup:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-secrets-setup-go:master
@@ -133,8 +121,6 @@ services:
       - secrets-setup-cache:/etc/edgex/pki
       - vault-init:/vault/init:z
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    depends_on:
-      - volume
 
   vault-worker:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:master
@@ -154,7 +140,7 @@ services:
       - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     depends_on:
-      - volume
+      - security-secrets-setup
       - consul
       - vault
 
@@ -173,6 +159,8 @@ services:
         - 'POSTGRES_DB=kong'
         - 'POSTGRES_USER=kong'
         - 'POSTGRES_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
+    depends_on:
+      - security-secrets-setup
 
   kong-migrations:
     image: kong:${KONG_VERSION:-2.0.1}
@@ -198,9 +186,8 @@ services:
     volumes:
       - consul-scripts:/consul/scripts:ro,z
     depends_on:
-      - kong-db
-      - volume
       - consul
+      - kong-db
 
   kong:
     image: kong:${KONG_VERSION:-2.0.1}
@@ -233,10 +220,9 @@ services:
     volumes:
       - consul-scripts:/consul/scripts:ro,z
     depends_on:
-        - kong-db
-        - kong-migrations
-        - volume
-        - consul
+      - consul
+      - kong-db
+      - kong-migrations
 
   edgex-proxy:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:master
@@ -263,8 +249,9 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
     depends_on:
-        - vault-worker
-        - kong
+      - consul
+      - vault-worker
+      - kong
 
 # end of containers for reverse proxy
 
@@ -291,7 +278,6 @@ services:
       - db-data:/data:z
       - /tmp/edgex/secrets/edgex-redis:/tmp/edgex/secrets/edgex-redis:z
     depends_on:
-      - volume
       - vault-worker
 
   logging:
@@ -313,7 +299,8 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
     depends_on:
-      - volume
+      - consul
+      - vault-worker
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:master
@@ -331,7 +318,13 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
+      - consul
       - logging
+      - scheduler
+      - notifications
+      - metadata
+      - data
+      - command
 
   notifications:
     image: nexus3.edgexfoundry.org:10004/docker-support-notifications-go:master
@@ -349,7 +342,10 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
     depends_on:
+      - consul
       - logging
+      - redis
+      - vault-worker
 
   metadata:
     image: nexus3.edgexfoundry.org:10004/docker-core-metadata-go:master
@@ -368,7 +364,11 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
     depends_on:
+      - consul
       - logging
+      - redis
+      - notifications
+      - vault-worker
 
   data:
     image: nexus3.edgexfoundry.org:10004/docker-core-data-go:master
@@ -387,7 +387,11 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
     depends_on:
+      - consul
       - logging
+      - redis
+      - metadata
+      - vault-worker
 
   command:
     image: nexus3.edgexfoundry.org:10004/docker-core-command-go:master
@@ -405,7 +409,11 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
     depends_on:
+      - consul
+      - logging
+      - redis
       - metadata
+      - vault-worker
 
   scheduler:
     image: nexus3.edgexfoundry.org:10004/docker-support-scheduler-go:master
@@ -425,16 +433,19 @@ services:
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
     depends_on:
-      - metadata
+      - consul
+      - logging
+      - redis
+      - vault-worker
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
+    entrypoint: ["/app-service-configurable"]
+    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     networks:
       edgex-network:
         aliases:
@@ -452,6 +463,7 @@ services:
       - consul
       - logging
       - data
+      - vault-worker
 
   rulesengine:
     image: emqx/kuiper:0.3.2
@@ -507,8 +519,10 @@ services:
       <<: *common-variables
       Service_Host: edgex-device-virtual
     depends_on:
-    - data
-    - command
+      - consul
+      - logging
+      - data
+      - metadata
 
   # device-random:
   #   image: nexus3.edgexfoundry.org:10004/docker-device-random-go:master


### PR DESCRIPTION
The purpose of this PR is to remove the ~100MB dependency of edgex-volume from the docker-compose files, and make modifications to the service dependencies to reflect the [service dependency graph](https://slack-files.com/TE66WRR3Q-F01148L6M7U-9a41e95836).  Several changes have been made to minimize spurious differences across mongo/redis, no-security/security, and amd64/arm64 versions of the compose files.  It is expected that these changes will also make it easier to remove the logging service in a future PR.

cc: @lenny-intel, @tingyuz, @andresrinivasan, @cloudxxx8 

### Testing instructions

Please ensure that you have the latest versions of all containers (`docker-compose -f whatever.yml pull`) and state (`docker volume prune`, `rm -fr /tmp/edgex/secrets`) before bringing up the stack.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>