### PR TITLE
refactor: Remove settings no longer needed on app-service-rules

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
@@ -432,8 +432,6 @@ services:
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
@@ -444,7 +442,7 @@ services:
           - edgex-app-service-configurable-rules
     environment:
       <<: *common-variables
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "false" # required since SecretStore not used and not configured
       edgex_profile: rules-engine
       Service_Host: edgex-app-service-configurable-rules
       Service_Port: 48100

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
@@ -206,8 +206,6 @@ services:
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
@@ -222,7 +220,6 @@ services:
       Service_Host: edgex-app-service-configurable-rules
       Service_Port: 48100
       MessageBus_SubscribeHost_Host: edgex-core-data
-      edgex_registry: consul://edgex-core-consul:8500
       Binding_PublishTopic: events
     depends_on:
       - consul

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
@@ -206,8 +206,6 @@ services:
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
@@ -221,7 +219,6 @@ services:
       edgex_profile: rules-engine
       Service_Host: edgex-app-service-configurable-rules
       Service_Port: 48100
-      edgex_registry: consul://edgex-core-consul:8500
       MessageBus_SubscribeHost_Host: edgex-core-data
       Binding_PublishTopic: events
     depends_on:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
@@ -432,8 +432,6 @@ services:
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
@@ -444,12 +442,11 @@ services:
           - edgex-app-service-configurable-rules
     environment:
       <<: *common-variables
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "false" # required since SecretStore not used and not configured
       edgex_profile: rules-engine
       Service_Host: edgex-app-service-configurable-rules
       Service_Port: 48100
       MessageBus_SubscribeHost_Host: edgex-core-data
-      edgex_registry: consul://edgex-core-consul:8500
       Binding_PublishTopic: events
     depends_on:
       - consul

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-arm64.yml
@@ -440,8 +440,6 @@ services:
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
@@ -452,12 +450,11 @@ services:
           - edgex-app-service-configurable-rules
     environment:
       <<: *common-variables
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "false" # required since SecretStore not used and not configured
       edgex_profile: rules-engine
       Service_Host: edgex-app-service-configurable-rules
       Service_Port: 48100
       MessageBus_SubscribeHost_Host: edgex-core-data
-      edgex_registry: consul://edgex-core-consul:8500
       Binding_PublishTopic: events
     depends_on:
       - consul

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
@@ -204,8 +204,6 @@ services:
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
@@ -220,7 +218,6 @@ services:
       Service_Host: edgex-app-service-configurable-rules
       Service_Port: 48100
       MessageBus_SubscribeHost_Host: edgex-core-data
-      edgex_registry: consul://edgex-core-consul:8500
       Binding_PublishTopic: events
     depends_on:
       - consul

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
@@ -204,8 +204,6 @@ services:
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
@@ -220,7 +218,6 @@ services:
       Service_Host: edgex-app-service-configurable-rules
       Service_Port: 48100
       MessageBus_SubscribeHost_Host: edgex-core-data
-      edgex_registry: consul://edgex-core-consul:8500
       Binding_PublishTopic: events
     depends_on:
       - consul

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis.yml
@@ -440,8 +440,6 @@ services:
 
   app-service-rules:
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
-    entrypoint: ["/app-service-configurable"]
-    command: ["--registry","--confdir=/res", "--skipVersionCheck=true"]
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
@@ -452,12 +450,11 @@ services:
           - edgex-app-service-configurable-rules
     environment:
       <<: *common-variables
-      EDGEX_SECURITY_SECRET_STORE: "false"
+      EDGEX_SECURITY_SECRET_STORE: "false" # required since SecretStore not used and not configured
       edgex_profile: rules-engine
       Service_Host: edgex-app-service-configurable-rules
       Service_Port: 48100
       MessageBus_SubscribeHost_Host: edgex-core-data
-      edgex_registry: consul://edgex-core-consul:8500
       Binding_PublishTopic: events
     depends_on:
       - consul


### PR DESCRIPTION

No longer need to skip version check. It handles master as the version from Core Data
No longer need to override edgex_registry. This is default in command line for Config Provider

closes #267
