### PR TITLE
refactor: Deprecated the Support Logging service

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
@@ -22,7 +22,6 @@ version: '3.4'
 x-common-env-variables: &common-variables
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
-  Clients_Logging_Host: edgex-support-logging
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -35,6 +34,8 @@ x-common-env-variables: &common-variables
   SecretStore_Host: edgex-vault
   SecretStore_ServerName: edgex-vault
   SecretStore_RootCaCertPath: /tmp/edgex/secrets/ca/ca.pem
+#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:
@@ -272,27 +273,32 @@ services:
       - consul
       - vault-worker
 
-  logging:
-    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:master
-    ports:
-      - "127.0.0.1:48061:48061"
-    container_name: edgex-support-logging
-    hostname: edgex-support-logging
-    networks:
-      - edgex-network
-    environment:
-      <<: *common-variables
-      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-support-logging/secrets-token.json
-      Service_Host: edgex-support-logging
-      Writable_Persistence: file
-      Databases_Primary_Type: file
-      Logging_EnableRemote: "false"
-    volumes:
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
-      - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
-    depends_on:
-      - consul
-      - vault-worker
+# The logging service has been deprecated in Geneva release and will be removed in the Hanoi release.
+# All services are configure to send logging to STDOUT, i.e. not remote which requires this logging service
+# If you still must use remote logging, un-comment the block below, all the related depends that have been commented out
+# and the related global override that are commented out at the top.
+#
+#  logging:
+#    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:master
+#    ports:
+#      - "127.0.0.1:48061:48061"
+#    container_name: edgex-support-logging
+#    hostname: edgex-support-logging
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-support-logging/secrets-token.json
+#      Service_Host: edgex-support-logging
+#      Writable_Persistence: file
+#      Databases_Primary_Type: file
+#      Logging_EnableRemote: "false"
+#    volumes:
+#      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+#      - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
+#    depends_on:
+#      - consul
+#      - vault-worker
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go-arm64:master
@@ -311,7 +317,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - scheduler
       - notifications
       - metadata
@@ -335,7 +341,7 @@ services:
       - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
       - vault-worker
 
@@ -357,7 +363,7 @@ services:
       - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
       - notifications
       - vault-worker
@@ -380,7 +386,7 @@ services:
       - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
       - metadata
       - vault-worker
@@ -402,7 +408,7 @@ services:
       - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
       - metadata
       - vault-worker
@@ -426,7 +432,7 @@ services:
       - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
       - vault-worker
 
@@ -451,7 +457,7 @@ services:
       Binding_PublishTopic: events
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
       - vault-worker
 
@@ -510,7 +516,7 @@ services:
       Service_Host: edgex-device-virtual
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
       - metadata
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
@@ -27,7 +27,6 @@ x-common-env-variables: &common-variables
   EDGEX_SECURITY_SECRET_STORE: "false"
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
-  Clients_Logging_Host: edgex-support-logging
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -37,6 +36,8 @@ x-common-env-variables: &common-variables
   Databases_Primary_Type: mongodb
   Databases_Primary_Host: edgex-mongo
   Databases_Primary_Port: 27017
+#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:
@@ -76,22 +77,27 @@ services:
     volumes:
       - db-data:/data/db:z
 
-  logging:
-    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:master
-    ports:
-      - "127.0.0.1:48061:48061"
-    container_name: edgex-support-logging
-    hostname: edgex-support-logging
-    networks:
-      - edgex-network
-    environment:
-      <<: *common-variables
-      Service_Host: edgex-support-logging
-      Writable_Persistence: file
-      Databases_Primary_Type: file
-      Logging_EnableRemote: "false"
-    depends_on:
-      - consul
+# The logging service has been deprecated in Geneva release and will be removed in the Hanoi release.
+# All services are configure to send logging to STDOUT, i.e. not remote which requires this logging service
+# If you still must use remote logging, un-comment the block below, all the related depends that have been commented out
+# and the related global override that are commented out at the top.
+#
+#  logging:
+#    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:master
+#    ports:
+#      - "127.0.0.1:48061:48061"
+#    container_name: edgex-support-logging
+#    hostname: edgex-support-logging
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-support-logging
+#      Writable_Persistence: file
+#      Databases_Primary_Type: file
+#      Logging_EnableRemote: "false"
+#    depends_on:
+#      - consul
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go-arm64:master
@@ -110,7 +116,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - scheduler
       - notifications
       - metadata
@@ -130,7 +136,7 @@ services:
       Service_Host: edgex-support-notifications
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
 
   metadata:
@@ -147,7 +153,7 @@ services:
       Notifications_Sender: edgex-core-metadata
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
       - notifications
 
@@ -165,7 +171,7 @@ services:
       Service_Host: edgex-core-data
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
       - metadata
 
@@ -182,7 +188,7 @@ services:
       Service_Host: edgex-core-command
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
       - metadata
 
@@ -201,7 +207,7 @@ services:
       IntervalActions_ScrubAged_Host: edgex-core-data
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
 
   app-service-rules:
@@ -223,7 +229,7 @@ services:
       Binding_PublishTopic: events
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
 
   rulesengine:
@@ -281,7 +287,7 @@ services:
       Service_Host: edgex-device-virtual
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
       - metadata
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
@@ -27,7 +27,6 @@ x-common-env-variables: &common-variables
   EDGEX_SECURITY_SECRET_STORE: "false"
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
-  Clients_Logging_Host: edgex-support-logging
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -37,6 +36,8 @@ x-common-env-variables: &common-variables
   Databases_Primary_Type: mongodb
   Databases_Primary_Host: edgex-mongo
   Databases_Primary_Port: 27017
+#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:
@@ -76,22 +77,27 @@ services:
     volumes:
       - db-data:/data/db:z
 
-  logging:
-    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go:master
-    ports:
-      - "127.0.0.1:48061:48061"
-    container_name: edgex-support-logging
-    hostname: edgex-support-logging
-    networks:
-      - edgex-network
-    environment:
-      <<: *common-variables
-      Service_Host: edgex-support-logging
-      Writable_Persistence: file
-      Databases_Primary_Type: file
-      Logging_EnableRemote: "false"
-    depends_on:
-      - consul
+# The logging service has been deprecated in Geneva release and will be removed in the Hanoi release.
+# All services are configure to send logging to STDOUT, i.e. not remote which requires this logging service
+# If you still must use remote logging, un-comment the block below, all the related depends that have been commented out
+# and the related global override that are commented out at the top.
+#
+#  logging:
+#    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go:master
+#    ports:
+#      - "127.0.0.1:48061:48061"
+#    container_name: edgex-support-logging
+#    hostname: edgex-support-logging
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-support-logging
+#      Writable_Persistence: file
+#      Databases_Primary_Type: file
+#      Logging_EnableRemote: "false"
+#    depends_on:
+#      - consul
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:master
@@ -110,7 +116,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - scheduler
       - notifications
       - metadata
@@ -130,7 +136,7 @@ services:
       Service_Host: edgex-support-notifications
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
 
   metadata:
@@ -147,7 +153,7 @@ services:
       Notifications_Sender: edgex-core-metadata
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
       - notifications
 
@@ -165,7 +171,7 @@ services:
       Service_Host: edgex-core-data
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
       - metadata
 
@@ -182,7 +188,7 @@ services:
       Service_Host: edgex-core-command
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
       - metadata
 
@@ -201,7 +207,7 @@ services:
       IntervalActions_ScrubAged_Host: edgex-core-data
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - mongo
 
   app-service-rules:
@@ -223,7 +229,7 @@ services:
       Binding_PublishTopic: events
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
 
   rulesengine:
@@ -281,7 +287,7 @@ services:
       Service_Host: edgex-device-virtual
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
       - metadata
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
@@ -22,8 +22,6 @@ version: '3.4'
 x-common-env-variables: &common-variables
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
-  Clients_Logging_Host: edgex-support-logging
-  Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
   Clients_Scheduler_Host: edgex-support-scheduler
@@ -35,6 +33,8 @@ x-common-env-variables: &common-variables
   SecretStore_Host: edgex-vault
   SecretStore_ServerName: edgex-vault
   SecretStore_RootCaCertPath: /tmp/edgex/secrets/ca/ca.pem
+#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:
@@ -272,27 +272,32 @@ services:
       - consul
       - vault-worker
 
-  logging:
-    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go:master
-    ports:
-      - "127.0.0.1:48061:48061"
-    container_name: edgex-support-logging
-    hostname: edgex-support-logging
-    networks:
-      - edgex-network
-    environment:
-      <<: *common-variables
-      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-support-logging/secrets-token.json
-      Service_Host: edgex-support-logging
-      Writable_Persistence: file
-      Databases_Primary_Type: file
-      Logging_EnableRemote: "false"
-    volumes:
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
-      - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
-    depends_on:
-      - consul
-      - vault-worker
+# The logging service has been deprecated in Geneva release and will be removed in the Hanoi release.
+# All services are configure to send logging to STDOUT, i.e. not remote which requires this logging service
+# If you still must use remote logging, un-comment the block below, all the related depends that have been commented out
+# and the related global override that are commented out at the top.
+#  
+#  logging:
+#    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go:master
+#    ports:
+#      - "127.0.0.1:48061:48061"
+#    container_name: edgex-support-logging
+#    hostname: edgex-support-logging
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-support-logging/secrets-token.json
+#      Service_Host: edgex-support-logging
+#      Writable_Persistence: file
+#      Databases_Primary_Type: file
+#      Logging_EnableRemote: "false"
+#    volumes:
+#      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+#      - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
+#    depends_on:
+#      - consul
+#      - vault-worker
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:master
@@ -311,7 +316,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment if re-enabled remote logging
       - scheduler
       - notifications
       - metadata
@@ -335,7 +340,7 @@ services:
       - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment if re-enabled remote logging
       - mongo
       - vault-worker
 
@@ -357,7 +362,7 @@ services:
       - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment if re-enabled remote logging
       - mongo
       - notifications
       - vault-worker
@@ -380,7 +385,7 @@ services:
       - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment if re-enabled remote logging
       - mongo
       - metadata
       - vault-worker
@@ -402,7 +407,7 @@ services:
       - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment if re-enabled remote logging
       - mongo
       - metadata
       - vault-worker
@@ -426,7 +431,7 @@ services:
       - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment if re-enabled remote logging
       - mongo
       - vault-worker
 
@@ -450,7 +455,7 @@ services:
       Binding_PublishTopic: events
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment if re-enabled remote logging
       - data
       - vault-worker
 
@@ -509,7 +514,7 @@ services:
       Service_Host: edgex-device-virtual
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment if re-enabled remote logging
       - data
       - metadata
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-arm64.yml
@@ -21,7 +21,6 @@ version: '3.4'
 x-common-env-variables: &common-variables
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
-  Clients_Logging_Host: edgex-support-logging
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -34,6 +33,8 @@ x-common-env-variables: &common-variables
   SecretStore_Host: edgex-vault
   SecretStore_ServerName: edgex-vault
   SecretStore_RootCaCertPath: /tmp/edgex/secrets/ca/ca.pem
+#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
 
 # REDIS5_PASSWORD_PATHNAME must have the same value as
 # security-secretstore-read/res/configuration.toml SecretStore.Passwordfile. Note edgex-go issue
@@ -280,27 +281,32 @@ services:
     depends_on:
       - vault-worker
 
-  logging:
-    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:master
-    ports:
-      - "127.0.0.1:48061:48061"
-    container_name: edgex-support-logging
-    hostname: edgex-support-logging
-    networks:
-      - edgex-network
-    environment:
-      <<: *common-variables
-      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-support-logging/secrets-token.json
-      Service_Host: edgex-support-logging
-      Writable_Persistence: file
-      Databases_Primary_Type: file
-      Logging_EnableRemote: "false"
-    volumes:
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
-      - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
-    depends_on:
-      - consul
-      - vault-worker
+# The logging service has been deprecated in Geneva release and will be removed in the Hanoi release.
+# All services are configure to send logging to STDOUT, i.e. not remote which requires this logging service
+# If you still must use remote logging, un-comment the block below, all the related depends that have been commented out
+# and the related global override that are commented out at the top.
+#
+#  logging:
+#    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:master
+#    ports:
+#      - "127.0.0.1:48061:48061"
+#    container_name: edgex-support-logging
+#    hostname: edgex-support-logging
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-support-logging/secrets-token.json
+#      Service_Host: edgex-support-logging
+#      Writable_Persistence: file
+#      Databases_Primary_Type: file
+#      Logging_EnableRemote: "false"
+#    volumes:
+#      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+#      - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
+#    depends_on:
+#      - consul
+#      - vault-worker
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go-arm64:master
@@ -319,7 +325,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - scheduler
       - notifications
       - metadata
@@ -343,7 +349,7 @@ services:
       - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - vault-worker
 
@@ -365,7 +371,7 @@ services:
       - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - notifications
       - vault-worker
@@ -388,7 +394,7 @@ services:
       - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - metadata
       - vault-worker
@@ -410,7 +416,7 @@ services:
       - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - metadata
       - vault-worker
@@ -434,7 +440,7 @@ services:
       - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - vault-worker
 
@@ -458,7 +464,7 @@ services:
       Binding_PublishTopic: events
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
       - vault-worker
 
@@ -517,7 +523,7 @@ services:
       Service_Host: edgex-device-virtual
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
       - metadata
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
@@ -27,7 +27,6 @@ x-common-env-variables: &common-variables
   EDGEX_SECURITY_SECRET_STORE: "false"
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
-  Clients_Logging_Host: edgex-support-logging
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -35,6 +34,8 @@ x-common-env-variables: &common-variables
   Clients_RulesEngine_Host: edgex-kuiper
   Clients_VirtualDevice_Host: edgex-device-virtual
   Databases_Primary_Host: edgex-redis
+#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:
@@ -74,22 +75,27 @@ services:
     volumes:
       - db-data:/data:z
 
-  logging:
-    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:master
-    ports:
-      - "127.0.0.1:48061:48061"
-    container_name: edgex-support-logging
-    hostname: edgex-support-logging
-    networks:
-      - edgex-network
-    environment:
-      <<: *common-variables
-      Service_Host: edgex-support-logging
-      Writable_Persistence: file
-      Databases_Primary_Type: file
-      Logging_EnableRemote: "false"
-    depends_on:
-      - consul
+# The logging service has been deprecated in Geneva release and will be removed in the Hanoi release.
+# All services are configure to send logging to STDOUT, i.e. not remote which requires this logging service
+# If you still must use remote logging, un-comment the block below, all the related depends that have been commented out
+# and the related global override that are commented out at the top.
+#
+#  logging:
+#    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:master
+#    ports:
+#      - "127.0.0.1:48061:48061"
+#    container_name: edgex-support-logging
+#    hostname: edgex-support-logging
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-support-logging
+#      Writable_Persistence: file
+#      Databases_Primary_Type: file
+#      Logging_EnableRemote: "false"
+#    depends_on:
+#      - consul
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go-arm64:master
@@ -108,7 +114,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - scheduler
       - notifications
       - metadata
@@ -128,7 +134,7 @@ services:
       Service_Host: edgex-support-notifications
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
 
   metadata:
@@ -145,7 +151,7 @@ services:
       Notifications_Sender: edgex-core-metadata
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - notifications
 
@@ -163,7 +169,7 @@ services:
       Service_Host: edgex-core-data
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - metadata
 
@@ -180,7 +186,7 @@ services:
       Service_Host: edgex-core-command
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - metadata
 
@@ -199,7 +205,7 @@ services:
       IntervalActions_ScrubAged_Host: edgex-core-data
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
 
   app-service-rules:
@@ -221,7 +227,7 @@ services:
       Binding_PublishTopic: events
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
 
   rulesengine:
@@ -279,7 +285,7 @@ services:
       Service_Host: edgex-device-virtual
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
       - metadata
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
@@ -27,7 +27,6 @@ x-common-env-variables: &common-variables
   EDGEX_SECURITY_SECRET_STORE: "false"
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
-  Clients_Logging_Host: edgex-support-logging
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -35,6 +34,8 @@ x-common-env-variables: &common-variables
   Clients_RulesEngine_Host: edgex-kuiper
   Clients_VirtualDevice_Host: edgex-device-virtual
   Databases_Primary_Host: edgex-redis
+#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:
@@ -74,22 +75,27 @@ services:
     volumes:
       - db-data:/data:z
 
-  logging:
-    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go:master
-    ports:
-      - "127.0.0.1:48061:48061"
-    container_name: edgex-support-logging
-    hostname: edgex-support-logging
-    networks:
-      - edgex-network
-    environment:
-      <<: *common-variables
-      Service_Host: edgex-support-logging
-      Writable_Persistence: file
-      Databases_Primary_Type: file
-      Logging_EnableRemote: "false"
-    depends_on:
-      - consul
+# The logging service has been deprecated in Geneva release and will be removed in the Hanoi release.
+# All services are configure to send logging to STDOUT, i.e. not remote which requires this logging service
+# If you still must use remote logging, un-comment the block below, all the related depends that have been commented out
+# and the related global override that are commented out at the top.
+#
+#  logging:
+#    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go:master
+#    ports:
+#      - "127.0.0.1:48061:48061"
+#    container_name: edgex-support-logging
+#    hostname: edgex-support-logging
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-support-logging
+#      Writable_Persistence: file
+#      Databases_Primary_Type: file
+#      Logging_EnableRemote: "false"
+#    depends_on:
+#      - consul
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:master
@@ -108,7 +114,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - scheduler
       - notifications
       - metadata
@@ -128,7 +134,7 @@ services:
       Service_Host: edgex-support-notifications
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
 
   metadata:
@@ -145,7 +151,7 @@ services:
       Notifications_Sender: edgex-core-metadata
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - notifications
 
@@ -163,7 +169,7 @@ services:
       Service_Host: edgex-core-data
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - metadata
 
@@ -180,7 +186,7 @@ services:
       Service_Host: edgex-core-command
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - metadata
 
@@ -199,7 +205,7 @@ services:
       IntervalActions_ScrubAged_Host: edgex-core-data
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
 
   app-service-rules:
@@ -221,7 +227,7 @@ services:
       Binding_PublishTopic: events
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
 
   rulesengine:
@@ -279,7 +285,7 @@ services:
       Service_Host: edgex-device-virtual
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
       - metadata
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis.yml
@@ -21,7 +21,6 @@ version: '3.4'
 x-common-env-variables: &common-variables
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
-  Clients_Logging_Host: edgex-support-logging
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -34,6 +33,8 @@ x-common-env-variables: &common-variables
   SecretStore_Host: edgex-vault
   SecretStore_ServerName: edgex-vault
   SecretStore_RootCaCertPath: /tmp/edgex/secrets/ca/ca.pem
+#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
 
 # REDIS5_PASSWORD_PATHNAME must have the same value as
 # security-secretstore-read/res/configuration.toml SecretStore.Passwordfile. Note edgex-go issue
@@ -280,27 +281,32 @@ services:
     depends_on:
       - vault-worker
 
-  logging:
-    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go:master
-    ports:
-      - "127.0.0.1:48061:48061"
-    container_name: edgex-support-logging
-    hostname: edgex-support-logging
-    networks:
-      - edgex-network
-    environment:
-      <<: *common-variables
-      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-support-logging/secrets-token.json
-      Service_Host: edgex-support-logging
-      Writable_Persistence: file
-      Databases_Primary_Type: file
-      Logging_EnableRemote: "false"
-    volumes:
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
-      - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
-    depends_on:
-      - consul
-      - vault-worker
+# The logging service has been deprecated in Geneva release and will be removed in the Hanoi release.
+# All services are configure to send logging to STDOUT, i.e. not remote which requires this logging service
+# If you still must use remote logging, un-comment the block below, all the related depends that have been commented out
+# and the related global override that are commented out at the top.
+#
+#  logging:
+#    image: nexus3.edgexfoundry.org:10004/docker-support-logging-go:master
+#    ports:
+#      - "127.0.0.1:48061:48061"
+#    container_name: edgex-support-logging
+#    hostname: edgex-support-logging
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-support-logging/secrets-token.json
+#      Service_Host: edgex-support-logging
+#      Writable_Persistence: file
+#      Databases_Primary_Type: file
+#      Logging_EnableRemote: "false"
+#    volumes:
+#      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+#      - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
+#    depends_on:
+#      - consul
+#      - vault-worker
 
   system:
     image: nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:master
@@ -319,7 +325,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - scheduler
       - notifications
       - metadata
@@ -343,7 +349,7 @@ services:
       - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - vault-worker
 
@@ -365,7 +371,7 @@ services:
       - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - notifications
       - vault-worker
@@ -388,7 +394,7 @@ services:
       - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - metadata
       - vault-worker
@@ -410,7 +416,7 @@ services:
       - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - metadata
       - vault-worker
@@ -434,7 +440,7 @@ services:
       - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - redis
       - vault-worker
 
@@ -458,7 +464,7 @@ services:
       Binding_PublishTopic: events
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
       - vault-worker
 
@@ -517,7 +523,7 @@ services:
       Service_Host: edgex-device-virtual
     depends_on:
       - consul
-      - logging
+#      - logging  # uncomment is re-enabled remote logging
       - data
       - metadata
 


### PR DESCRIPTION
Support logging has been deprecated via commenting out appropriate sections in the compose files.

closes #270
