### PR TITLE
fix: Explicity disable remote logging to override any old configuration used

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
@@ -34,8 +34,10 @@ x-common-env-variables: &common-variables
   SecretStore_Host: edgex-vault
   SecretStore_ServerName: edgex-vault
   SecretStore_RootCaCertPath: /tmp/edgex/secrets/ca/ca.pem
-#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
-#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
+  # Require in case old configuration from previous release used.
+  # Change to "true" if re-enabling logging service for remote logging
+  Logging_EnableRemote: "false"
+  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
@@ -36,8 +36,10 @@ x-common-env-variables: &common-variables
   Databases_Primary_Type: mongodb
   Databases_Primary_Host: edgex-mongo
   Databases_Primary_Port: 27017
-#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
-#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
+  # Require in case old configuration from previous release used.
+  # Change to "true" if re-enabling logging service for remote logging
+  Logging_EnableRemote: "false"
+  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
@@ -36,8 +36,10 @@ x-common-env-variables: &common-variables
   Databases_Primary_Type: mongodb
   Databases_Primary_Host: edgex-mongo
   Databases_Primary_Port: 27017
-#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
-#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
+  # Require in case old configuration from previous release used.
+  # Change to "true" if re-enabling logging service for remote logging
+  Logging_EnableRemote: "false"
+  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
@@ -33,8 +33,10 @@ x-common-env-variables: &common-variables
   SecretStore_Host: edgex-vault
   SecretStore_ServerName: edgex-vault
   SecretStore_RootCaCertPath: /tmp/edgex/secrets/ca/ca.pem
-#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
-#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
+  # Require in case old configuration from previous release used.
+  # Change to "true" if re-enabling logging service for remote logging
+  Logging_EnableRemote: "false"
+  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-arm64.yml
@@ -33,8 +33,10 @@ x-common-env-variables: &common-variables
   SecretStore_Host: edgex-vault
   SecretStore_ServerName: edgex-vault
   SecretStore_RootCaCertPath: /tmp/edgex/secrets/ca/ca.pem
-#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
-#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
+  # Require in case old configuration from previous release used.
+  # Change to "true" if re-enabling logging service for remote logging
+  Logging_EnableRemote: "false"
+  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
 
 # REDIS5_PASSWORD_PATHNAME must have the same value as
 # security-secretstore-read/res/configuration.toml SecretStore.Passwordfile. Note edgex-go issue

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
@@ -34,8 +34,10 @@ x-common-env-variables: &common-variables
   Clients_RulesEngine_Host: edgex-kuiper
   Clients_VirtualDevice_Host: edgex-device-virtual
   Databases_Primary_Host: edgex-redis
-#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
-#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
+  # Require in case old configuration from previous release used.
+  # Change to "true" if re-enabling logging service for remote logging
+  Logging_EnableRemote: "false"
+  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
@@ -34,8 +34,10 @@ x-common-env-variables: &common-variables
   Clients_RulesEngine_Host: edgex-kuiper
   Clients_VirtualDevice_Host: edgex-device-virtual
   Databases_Primary_Host: edgex-redis
-#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
-#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
+  # Require in case old configuration from previous release used.
+  # Change to "true" if re-enabling logging service for remote logging
+  Logging_EnableRemote: "false"
+  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis.yml
@@ -33,8 +33,10 @@ x-common-env-variables: &common-variables
   SecretStore_Host: edgex-vault
   SecretStore_ServerName: edgex-vault
   SecretStore_RootCaCertPath: /tmp/edgex/secrets/ca/ca.pem
-#  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
-#  Logging_EnableRemote: "true" # un-comment if re-enabling logging service for remote logging
+  # Require in case old configuration from previous release used.
+  # Change to "true" if re-enabling logging service for remote logging
+  Logging_EnableRemote: "false"
+  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
 
 # REDIS5_PASSWORD_PATHNAME must have the same value as
 # security-secretstore-read/res/configuration.toml SecretStore.Passwordfile. Note edgex-go issue


### PR DESCRIPTION
closes #275

If existing Fuji deployment is upgraded to Geneva, remote logging will be enabled in the configuration stored in Consul. 

This PR explicitly disables remote logging with environment override for this scenario