### PR TITLE
fix: Restore override for Notifications Host in Mongo compose file

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-arm64.yml
@@ -37,7 +37,7 @@ x-common-env-variables: &common-variables
   # Require in case old configuration from previous release used.
   # Change to "true" if re-enabling logging service for remote logging
   Logging_EnableRemote: "false"
-  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+  #  Clients_Logging_Host: edgex-support-logging # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty-arm64.yml
@@ -39,7 +39,7 @@ x-common-env-variables: &common-variables
   # Require in case old configuration from previous release used.
   # Change to "true" if re-enabling logging service for remote logging
   Logging_EnableRemote: "false"
-  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+  #  Clients_Logging_Host: edgex-support-logging # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo-no-secty.yml
@@ -39,7 +39,7 @@ x-common-env-variables: &common-variables
   # Require in case old configuration from previous release used.
   # Change to "true" if re-enabling logging service for remote logging
   Logging_EnableRemote: "false"
-  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+  #  Clients_Logging_Host: edgex-support-logging # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-mongo.yml
@@ -22,6 +22,7 @@ version: '3.4'
 x-common-env-variables: &common-variables
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
+  Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
   Clients_Scheduler_Host: edgex-support-scheduler
@@ -36,7 +37,7 @@ x-common-env-variables: &common-variables
   # Require in case old configuration from previous release used.
   # Change to "true" if re-enabling logging service for remote logging
   Logging_EnableRemote: "false"
-  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+  #  Clients_Logging_Host: edgex-support-logging # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-arm64.yml
@@ -36,7 +36,7 @@ x-common-env-variables: &common-variables
   # Require in case old configuration from previous release used.
   # Change to "true" if re-enabling logging service for remote logging
   Logging_EnableRemote: "false"
-  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+  #  Clients_Logging_Host: edgex-support-logging # un-comment if re-enabling logging service for remote logging
 
 # REDIS5_PASSWORD_PATHNAME must have the same value as
 # security-secretstore-read/res/configuration.toml SecretStore.Passwordfile. Note edgex-go issue

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty-arm64.yml
@@ -37,7 +37,7 @@ x-common-env-variables: &common-variables
   # Require in case old configuration from previous release used.
   # Change to "true" if re-enabling logging service for remote logging
   Logging_EnableRemote: "false"
-  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+  #  Clients_Logging_Host: edgex-support-logging # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml
@@ -37,7 +37,7 @@ x-common-env-variables: &common-variables
   # Require in case old configuration from previous release used.
   # Change to "true" if re-enabling logging service for remote logging
   Logging_EnableRemote: "false"
-  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+  #  Clients_Logging_Host: edgex-support-logging # un-comment if re-enabling logging service for remote logging
 
 volumes:
   db-data:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-redis.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-redis.yml
@@ -36,7 +36,7 @@ x-common-env-variables: &common-variables
   # Require in case old configuration from previous release used.
   # Change to "true" if re-enabling logging service for remote logging
   Logging_EnableRemote: "false"
-  #  Clients_Notifications_Host: edgex-support-notifications # un-comment if re-enabling logging service for remote logging
+  #  Clients_Logging_Host: edgex-support-logging # un-comment if re-enabling logging service for remote logging
 
 # REDIS5_PASSWORD_PATHNAME must have the same value as
 # security-secretstore-read/res/configuration.toml SecretStore.Passwordfile. Note edgex-go issue


### PR DESCRIPTION
Also, fixed comment for Logging Host in all compose files

closes #279
closes https://github.com/edgexfoundry/edgex-go/issues/2543