### PR TITLE
fix: Geneva 1.2.1 dot release updates

### DIFF
--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-arm64.yml
@@ -350,6 +350,7 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-core-metadata
+      Service_Timeout: "20000"
       Notifications_Sender: edgex-core-metadata
       SecretStore_TokenFile: /tmp/edgex/secrets/edgex-core-metadata/secrets-token.json
     volumes:

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-arm64.yml
@@ -27,6 +27,7 @@ version: '3.4'
 x-common-env-variables: &common-variables
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
+  Clients_Data_Host: edgex-core-data # For device Services
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -66,9 +67,7 @@ services:
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     networks:
-      edgex-network:
-        aliases:
-            - edgex-core-consul
+      - edgex-network
     volumes:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
@@ -89,9 +88,7 @@ services:
     container_name: edgex-vault
     hostname: edgex-vault
     networks:
-      edgex-network:
-        aliases:
-            - edgex-vault
+      - edgex-network
     ports:
       - "127.0.0.1:8200:8200"
     cap_add:
@@ -113,7 +110,7 @@ services:
       - security-secrets-setup
 
   security-secrets-setup:
-    image: edgexfoundry/docker-edgex-secrets-setup-go-arm64:1.2.0
+    image: edgexfoundry/docker-edgex-secrets-setup-go-arm64:1.2.1
     container_name: edgex-secrets-setup
     hostname: edgex-secrets-setup
     tmpfs:
@@ -126,15 +123,13 @@ services:
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
 
   vault-worker:
-    image: edgexfoundry/docker-edgex-security-secretstore-setup-go-arm64:1.2.0
+    image: edgexfoundry/docker-edgex-security-secretstore-setup-go-arm64:1.2.1
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
     environment:
       - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
     networks:
-      edgex-network:
-        aliases:
-            - edgex-vault-worker
+      - edgex-network
     tmpfs:
       - /run
     volumes:
@@ -152,9 +147,7 @@ services:
     container_name: kong-db
     hostname: kong-db
     networks:
-      edgex-network:
-        aliases:
-            - kong-db
+      - edgex-network
     ports:
         - "127.0.0.1:5432:5432"
     environment:
@@ -168,9 +161,7 @@ services:
     image: kong:${KONG_VERSION:-2.0.1}-ubuntu
     container_name: kong-migrations
     networks:
-      edgex-network:
-        aliases:
-            - kong-migrations
+      - edgex-network
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
@@ -196,9 +187,7 @@ services:
     container_name: kong
     hostname: kong
     networks:
-      edgex-network:
-        aliases:
-            - kong
+      - edgex-network
     ports:
         - "8000:8000"
         - "127.0.0.1:8001:8001"
@@ -227,7 +216,7 @@ services:
       - kong-migrations
 
   edgex-proxy:
-    image: edgexfoundry/docker-edgex-security-proxy-setup-go-arm64:1.2.0
+    image: edgexfoundry/docker-edgex-security-proxy-setup-go-arm64:1.2.1
     container_name: edgex-proxy
     hostname: edgex-proxy
     entrypoint: >
@@ -236,9 +225,7 @@ services:
       until /consul/scripts/consul-svc-healthy.sh security-secretstore-setup; do sleep 1; done;
       /edgex/security-proxy-setup --init=true"
     networks:
-      edgex-network:
-        aliases:
-            - edgex-proxy
+      - edgex-network
     environment:
       <<: *common-variables
       KongURL_Server: kong
@@ -286,7 +273,7 @@ services:
 # and the related global override that are commented out at the top.
 #
 #  logging:
-#    image: edgexfoundry/docker-support-logging-go-arm64:1.2.0
+#    image: edgexfoundry/docker-support-logging-go-arm64:1.2.1
 #    ports:
 #      - "127.0.0.1:48061:48061"
 #    container_name: edgex-support-logging
@@ -308,7 +295,7 @@ services:
 #      - vault-worker
 
   system:
-    image: edgexfoundry/docker-sys-mgmt-agent-go-arm64:1.2.0
+    image: edgexfoundry/docker-sys-mgmt-agent-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48090:48090"
     container_name: edgex-sys-mgmt-agent
@@ -332,7 +319,7 @@ services:
       - command
 
   notifications:
-    image: edgexfoundry/docker-support-notifications-go-arm64:1.2.0
+    image: edgexfoundry/docker-support-notifications-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48060:48060"
     container_name: edgex-support-notifications
@@ -353,7 +340,7 @@ services:
       - vault-worker
 
   metadata:
-    image: edgexfoundry/docker-core-metadata-go-arm64:1.2.0
+    image: edgexfoundry/docker-core-metadata-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48081:48081"
     container_name: edgex-core-metadata
@@ -376,7 +363,7 @@ services:
       - vault-worker
 
   data:
-    image: edgexfoundry/docker-core-data-go-arm64:1.2.0
+    image: edgexfoundry/docker-core-data-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48080:48080"
       - "127.0.0.1:5563:5563"
@@ -399,7 +386,7 @@ services:
       - vault-worker
 
   command:
-    image: edgexfoundry/docker-core-command-go-arm64:1.2.0
+    image: edgexfoundry/docker-core-command-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48082:48082"
     container_name: edgex-core-command
@@ -421,7 +408,7 @@ services:
       - vault-worker
 
   scheduler:
-    image: edgexfoundry/docker-support-scheduler-go-arm64:1.2.0
+    image: edgexfoundry/docker-support-scheduler-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48085:48085"
     container_name: edgex-support-scheduler
@@ -444,15 +431,13 @@ services:
       - vault-worker
 
   app-service-rules:
-    image: edgexfoundry/docker-app-service-configurable-arm64:1.1.0
+    image: edgexfoundry/docker-app-service-configurable-arm64:1.2.0
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
     networks:
-      edgex-network:
-        aliases:
-          - edgex-app-service-configurable-rules
+      - edgex-network
     environment:
       <<: *common-variables
       EDGEX_SECURITY_SECRET_STORE: "false" # required since SecretStore not used and not configured
@@ -469,16 +454,14 @@ services:
       - vault-worker
 
   rulesengine:
-    image: emqx/kuiper:0.3.2
+    image: emqx/kuiper:0.4.2
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"
     container_name: edgex-kuiper
     hostname: edgex-kuiper
     networks:
-      edgex-network:
-        aliases:
-          - edgex-kuiper
+      - edgex-network
     environment:
       # KUIPER_DEBUG: "true"
       KUIPER_CONSOLE_LOG: "true"
@@ -495,15 +478,13 @@ services:
   # If still required, simply uncomment the block below and comment out the block above.
   #
   # rulesengine:
-  #   image: edgexfoundry/docker-support-rulesengine-arm64:1.2.0
+  #   image: edgexfoundry/docker-support-rulesengine-arm64:1.2.1
   #   ports:
   #     - "127.0.0.1:48075:48075"
   #   container_name: edgex-support-rulesengine
   #   hostname: edgex-support-rulesengine
   #   networks:
-  #     edgex-network:
-  #       aliases:
-  #         - edgex-support-rulesengine
+  #     - edgex-network
   #   depends_on:
   #     - app-service-rules
 
@@ -512,18 +493,17 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.0
+    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.1
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual
     hostname: edgex-device-virtual
     networks:
-      edgex-network:
-        aliases:
-        - edgex-device-virtual
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
+      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -531,90 +511,85 @@ services:
       - metadata
 
   device-rest:
-    image: edgexfoundry/docker-device-rest-go-arm64:1.1.0
+    image: edgexfoundry/docker-device-rest-go-arm64:1.1.1
     ports:
       - "127.0.0.1:49986:49986"
     container_name: edgex-device-rest
     hostname: edgex-device-rest
     networks:
-      edgex-network:
-        aliases:
-          - edgex-device-rest
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
+      Service_Timeout: "20000"
     depends_on:
       - data
       - command
   #      - logging  # uncomment if re-enabled remote logging
 
-  # device-random:
-  #   image: edgexfoundry/docker-device-random-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49988:49988"
-  #   container_name: edgex-device-random
-  #   hostname: edgex-device-random
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-random
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-random
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-mqtt:
-  #   image: edgexfoundry/docker-device-mqtt-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49982:49982"
-  #   container_name: edgex-device-mqtt
-  #   hostname: edgex-device-mqtt
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-mqtt
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-mqtt
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-modbus:
-  #   image: edgexfoundry/docker-device-modbus-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49991:49991"
-  #   container_name: edgex-device-modbus
-  #   hostname: edgex-device-modbus
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-modbus
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-modbus
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-snmp:
-  #   image: edgexfoundry/docker-device-snmp-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49993:49993"
-  #   container_name: edgex-device-snmp
-  #   hostname: edgex-device-snmp
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-snmp
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-snmp
-  #   depends_on:
-  #     - data
-  #     - command
+#  device-random:
+#    image: edgexfoundry/docker-device-random-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49988:49988"
+#    container_name: edgex-device-random
+#    hostname: edgex-device-random
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-random
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-mqtt:
+#    image: edgexfoundry/docker-device-mqtt-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49982:49982"
+#    container_name: edgex-device-mqtt
+#    hostname: edgex-device-mqtt
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-mqtt
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-modbus:
+#    image: edgexfoundry/docker-device-modbus-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49991:49991"
+#    container_name: edgex-device-modbus
+#    hostname: edgex-device-modbus
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-modbus
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-snmp:
+#    image: edgexfoundry/docker-device-snmp-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49993:49993"
+#    container_name: edgex-device-snmp
+#    hostname: edgex-device-snmp
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-snmp
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
 
 networks:
   edgex-network:

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-arm64.yml
@@ -504,7 +504,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
-      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -522,7 +521,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
-      Service_Timeout: "20000"
     depends_on:
       - data
       - command
@@ -539,7 +537,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-random
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -555,7 +552,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-mqtt
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -571,7 +567,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-modbus
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -587,7 +582,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-snmp
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-arm64.yml
@@ -455,7 +455,7 @@ services:
       - vault-worker
 
   rulesengine:
-    image: emqx/kuiper:0.4.2
+    image: emqx/kuiper:0.4.2-alpine
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty-arm64.yml
@@ -239,7 +239,7 @@ services:
       - data
 
   rulesengine:
-    image: emqx/kuiper:0.4.2
+    image: emqx/kuiper:0.4.2-alpine
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty-arm64.yml
@@ -33,6 +33,7 @@ x-common-env-variables: &common-variables
   EDGEX_SECURITY_SECRET_STORE: "false"
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
+  Clients_Data_Host: edgex-core-data # For device Services
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -62,9 +63,7 @@ services:
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     networks:
-      edgex-network:
-        aliases:
-            - edgex-core-consul
+      - edgex-network
     volumes:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
@@ -91,7 +90,7 @@ services:
 # and the related global override that are commented out at the top.
 #
 #  logging:
-#    image: edgexfoundry/docker-support-logging-go-arm64:1.2.0
+#    image: edgexfoundry/docker-support-logging-go-arm64:1.2.1
 #    ports:
 #      - "127.0.0.1:48061:48061"
 #    container_name: edgex-support-logging
@@ -108,7 +107,7 @@ services:
 #      - consul
 
   system:
-    image: edgexfoundry/docker-sys-mgmt-agent-go-arm64:1.2.0
+    image: edgexfoundry/docker-sys-mgmt-agent-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48090:48090"
     container_name: edgex-sys-mgmt-agent
@@ -132,7 +131,7 @@ services:
       - command
 
   notifications:
-    image: edgexfoundry/docker-support-notifications-go-arm64:1.2.0
+    image: edgexfoundry/docker-support-notifications-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48060:48060"
     container_name: edgex-support-notifications
@@ -148,7 +147,7 @@ services:
       - mongo
 
   metadata:
-    image: edgexfoundry/docker-core-metadata-go-arm64:1.2.0
+    image: edgexfoundry/docker-core-metadata-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48081:48081"
     container_name: edgex-core-metadata
@@ -166,7 +165,7 @@ services:
       - notifications
 
   data:
-    image: edgexfoundry/docker-core-data-go-arm64:1.2.0
+    image: edgexfoundry/docker-core-data-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48080:48080"
       - "127.0.0.1:5563:5563"
@@ -184,7 +183,7 @@ services:
       - metadata
 
   command:
-    image: edgexfoundry/docker-core-command-go-arm64:1.2.0
+    image: edgexfoundry/docker-core-command-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48082:48082"
     container_name: edgex-core-command
@@ -201,7 +200,7 @@ services:
       - metadata
 
   scheduler:
-    image: edgexfoundry/docker-support-scheduler-go-arm64:1.2.0
+    image: edgexfoundry/docker-support-scheduler-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48085:48085"
     container_name: edgex-support-scheduler
@@ -219,15 +218,13 @@ services:
       - mongo
 
   app-service-rules:
-    image: edgexfoundry/docker-app-service-configurable-arm64:1.1.0
+    image: edgexfoundry/docker-app-service-configurable-arm64:1.2.0
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
     networks:
-      edgex-network:
-        aliases:
-          - edgex-app-service-configurable-rules
+      - edgex-network
     environment:
       <<: *common-variables
       edgex_profile: rules-engine
@@ -241,16 +238,14 @@ services:
       - data
 
   rulesengine:
-    image: emqx/kuiper:0.3.2
+    image: emqx/kuiper:0.4.2
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"
     container_name: edgex-kuiper
     hostname: edgex-kuiper
     networks:
-      edgex-network:
-        aliases:
-          - edgex-kuiper
+      - edgex-network
     environment:
       # KUIPER_DEBUG: "true"
       KUIPER_CONSOLE_LOG: "true"
@@ -267,15 +262,13 @@ services:
   # If still required, simply uncomment the block below and comment out the block above.
   #
   # rulesengine:
-  #   image: edgexfoundry/docker-support-rulesengine-arm64:1.2.0
+  #   image: edgexfoundry/docker-support-rulesengine-arm64:1.2.1
   #   ports:
   #     - "127.0.0.1:48075:48075"
   #   container_name: edgex-support-rulesengine
   #   hostname: edgex-support-rulesengine
   #   networks:
-  #     edgex-network:
-  #       aliases:
-  #         - edgex-support-rulesengine
+  #     - edgex-network
   #   depends_on:
   #     - app-service-rules
 
@@ -284,18 +277,17 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.0
+    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.1
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual
     hostname: edgex-device-virtual
     networks:
-      edgex-network:
-        aliases:
-        - edgex-device-virtual
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
+      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -303,90 +295,85 @@ services:
       - metadata
 
   device-rest:
-    image: edgexfoundry/docker-device-rest-go-arm64:1.1.0
+    image: edgexfoundry/docker-device-rest-go-arm64:1.1.1
     ports:
       - "127.0.0.1:49986:49986"
     container_name: edgex-device-rest
     hostname: edgex-device-rest
     networks:
-      edgex-network:
-        aliases:
-          - edgex-device-rest
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
+      Service_Timeout: "20000"
     depends_on:
       - data
       - command
   #      - logging  # uncomment if re-enabled remote logging
 
-  # device-random:
-  #   image: edgexfoundry/docker-device-random-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49988:49988"
-  #   container_name: edgex-device-random
-  #   hostname: edgex-device-random
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-random
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-random
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-mqtt:
-  #   image: edgexfoundry/docker-device-mqtt-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49982:49982"
-  #   container_name: edgex-device-mqtt
-  #   hostname: edgex-device-mqtt
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-mqtt
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-mqtt
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-modbus:
-  #   image: edgexfoundry/docker-device-modbus-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49991:49991"
-  #   container_name: edgex-device-modbus
-  #   hostname: edgex-device-modbus
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-modbus
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-modbus
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-snmp:
-  #   image: edgexfoundry/docker-device-snmp-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49993:49993"
-  #   container_name: edgex-device-snmp
-  #   hostname: edgex-device-snmp
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-snmp
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-snmp
-  #   depends_on:
-  #     - data
-  #     - command
+#  device-random:
+#    image: edgexfoundry/docker-device-random-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49988:49988"
+#    container_name: edgex-device-random
+#    hostname: edgex-device-random
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-random
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-mqtt:
+#    image: edgexfoundry/docker-device-mqtt-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49982:49982"
+#    container_name: edgex-device-mqtt
+#    hostname: edgex-device-mqtt
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-mqtt
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-modbus:
+#    image: edgexfoundry/docker-device-modbus-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49991:49991"
+#    container_name: edgex-device-modbus
+#    hostname: edgex-device-modbus
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-modbus
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-snmp:
+#    image: edgexfoundry/docker-device-snmp-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49993:49993"
+#    container_name: edgex-device-snmp
+#    hostname: edgex-device-snmp
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-snmp
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
 
 networks:
   edgex-network:

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty-arm64.yml
@@ -288,7 +288,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
-      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -306,7 +305,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
-      Service_Timeout: "20000"
     depends_on:
       - data
       - command
@@ -323,7 +321,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-random
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -339,7 +336,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-mqtt
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -355,7 +351,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-modbus
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -371,7 +366,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-snmp
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty-arm64.yml
@@ -157,6 +157,7 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-core-metadata
+      Service_Timeout: "20000"
       Notifications_Sender: edgex-core-metadata
     depends_on:
       - consul

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty.yml
@@ -239,7 +239,7 @@ services:
       - data
 
   rulesengine:
-    image: emqx/kuiper:0.4.2
+    image: emqx/kuiper:0.4.2-alpine
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty.yml
@@ -288,7 +288,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
-      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -306,7 +305,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
-      Service_Timeout: "20000"
     depends_on:
       - data
       - command
@@ -323,7 +321,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-random
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -339,7 +336,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-mqtt
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -355,7 +351,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-modbus
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -371,7 +366,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-snmp
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty.yml
@@ -33,6 +33,7 @@ x-common-env-variables: &common-variables
   EDGEX_SECURITY_SECRET_STORE: "false"
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
+  Clients_Data_Host: edgex-core-data # For device Services
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -62,9 +63,7 @@ services:
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     networks:
-      edgex-network:
-        aliases:
-            - edgex-core-consul
+      - edgex-network
     volumes:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
@@ -91,7 +90,7 @@ services:
 # and the related global override that are commented out at the top.
 #
 #  logging:
-#    image: edgexfoundry/docker-support-logging-go:1.2.0
+#    image: edgexfoundry/docker-support-logging-go:1.2.1
 #    ports:
 #      - "127.0.0.1:48061:48061"
 #    container_name: edgex-support-logging
@@ -108,7 +107,7 @@ services:
 #      - consul
 
   system:
-    image: edgexfoundry/docker-sys-mgmt-agent-go:1.2.0
+    image: edgexfoundry/docker-sys-mgmt-agent-go:1.2.1
     ports:
       - "127.0.0.1:48090:48090"
     container_name: edgex-sys-mgmt-agent
@@ -132,7 +131,7 @@ services:
       - command
 
   notifications:
-    image: edgexfoundry/docker-support-notifications-go:1.2.0
+    image: edgexfoundry/docker-support-notifications-go:1.2.1
     ports:
       - "127.0.0.1:48060:48060"
     container_name: edgex-support-notifications
@@ -148,7 +147,7 @@ services:
       - mongo
 
   metadata:
-    image: edgexfoundry/docker-core-metadata-go:1.2.0
+    image: edgexfoundry/docker-core-metadata-go:1.2.1
     ports:
       - "127.0.0.1:48081:48081"
     container_name: edgex-core-metadata
@@ -166,7 +165,7 @@ services:
       - notifications
 
   data:
-    image: edgexfoundry/docker-core-data-go:1.2.0
+    image: edgexfoundry/docker-core-data-go:1.2.1
     ports:
       - "127.0.0.1:48080:48080"
       - "127.0.0.1:5563:5563"
@@ -184,7 +183,7 @@ services:
       - metadata
 
   command:
-    image: edgexfoundry/docker-core-command-go:1.2.0
+    image: edgexfoundry/docker-core-command-go:1.2.1
     ports:
       - "127.0.0.1:48082:48082"
     container_name: edgex-core-command
@@ -201,7 +200,7 @@ services:
       - metadata
 
   scheduler:
-    image: edgexfoundry/docker-support-scheduler-go:1.2.0
+    image: edgexfoundry/docker-support-scheduler-go:1.2.1
     ports:
       - "127.0.0.1:48085:48085"
     container_name: edgex-support-scheduler
@@ -219,15 +218,13 @@ services:
       - mongo
 
   app-service-rules:
-    image: edgexfoundry/docker-app-service-configurable:1.1.0
+    image: edgexfoundry/docker-app-service-configurable:1.2.0
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
     networks:
-      edgex-network:
-        aliases:
-          - edgex-app-service-configurable-rules
+      - edgex-network
     environment:
       <<: *common-variables
       edgex_profile: rules-engine
@@ -241,16 +238,14 @@ services:
       - data
 
   rulesengine:
-    image: emqx/kuiper:0.3.2
+    image: emqx/kuiper:0.4.2
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"
     container_name: edgex-kuiper
     hostname: edgex-kuiper
     networks:
-      edgex-network:
-        aliases:
-          - edgex-kuiper
+      - edgex-network
     environment:
       # KUIPER_DEBUG: "true"
       KUIPER_CONSOLE_LOG: "true"
@@ -267,15 +262,13 @@ services:
   # If still required, simply uncomment the block below and comment out the block above.
   #
   # rulesengine:
-  #   image: edgexfoundry/docker-support-rulesengine:1.2.0
+  #   image: edgexfoundry/docker-support-rulesengine:1.2.1
   #   ports:
   #     - "127.0.0.1:48075:48075"
   #   container_name: edgex-support-rulesengine
   #   hostname: edgex-support-rulesengine
   #   networks:
-  #     edgex-network:
-  #       aliases:
-  #         - edgex-support-rulesengine
+  #     - edgex-network
   #   depends_on:
   #     - app-service-rules
 
@@ -284,18 +277,17 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go:1.2.0
+    image: edgexfoundry/docker-device-virtual-go:1.2.1
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual
     hostname: edgex-device-virtual
     networks:
-      edgex-network:
-        aliases:
-        - edgex-device-virtual
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
+      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -303,90 +295,85 @@ services:
       - metadata
 
   device-rest:
-    image: edgexfoundry/docker-device-rest-go:1.1.0
+    image: edgexfoundry/docker-device-rest-go:1.1.1
     ports:
       - "127.0.0.1:49986:49986"
     container_name: edgex-device-rest
     hostname: edgex-device-rest
     networks:
-      edgex-network:
-        aliases:
-          - edgex-device-rest
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
+      Service_Timeout: "20000"
     depends_on:
       - data
       - command
   #      - logging  # uncomment if re-enabled remote logging
 
-  # device-random:
-  #   image: edgexfoundry/docker-device-random-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49988:49988"
-  #   container_name: edgex-device-random
-  #   hostname: edgex-device-random
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-random
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-random
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-mqtt:
-  #   image: edgexfoundry/docker-device-mqtt-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49982:49982"
-  #   container_name: edgex-device-mqtt
-  #   hostname: edgex-device-mqtt
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-mqtt
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-mqtt
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-modbus:
-  #   image: edgexfoundry/docker-device-modbus-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49991:49991"
-  #   container_name: edgex-device-modbus
-  #   hostname: edgex-device-modbus
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-modbus
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-modbus
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-snmp:
-  #   image: edgexfoundry/docker-device-snmp-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49993:49993"
-  #   container_name: edgex-device-snmp
-  #   hostname: edgex-device-snmp
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-snmp
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-snmp
-  #   depends_on:
-  #     - data
-  #     - command
+#  device-random:
+#    image: edgexfoundry/docker-device-random-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49988:49988"
+#    container_name: edgex-device-random
+#    hostname: edgex-device-random
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-random
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-mqtt:
+#    image: edgexfoundry/docker-device-mqtt-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49982:49982"
+#    container_name: edgex-device-mqtt
+#    hostname: edgex-device-mqtt
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-mqtt
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-modbus:
+#    image: edgexfoundry/docker-device-modbus-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49991:49991"
+#    container_name: edgex-device-modbus
+#    hostname: edgex-device-modbus
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-modbus
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-snmp:
+#    image: edgexfoundry/docker-device-snmp-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49993:49993"
+#    container_name: edgex-device-snmp
+#    hostname: edgex-device-snmp
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-snmp
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
 
 networks:
   edgex-network:

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty.yml
@@ -157,6 +157,7 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-core-metadata
+      Service_Timeout: "20000"
       Notifications_Sender: edgex-core-metadata
     depends_on:
       - consul

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo.yml
@@ -350,6 +350,7 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-core-metadata
+      Service_Timeout: "20000"
       Notifications_Sender: edgex-core-metadata
       SecretStore_TokenFile: /tmp/edgex/secrets/edgex-core-metadata/secrets-token.json
     volumes:

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo.yml
@@ -503,7 +503,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
-      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -521,7 +520,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
-      Service_Timeout: "20000"
     depends_on:
       - data
       - command
@@ -537,7 +535,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-random
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -553,7 +550,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-mqtt
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -569,7 +565,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-modbus
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -585,7 +580,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-snmp
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo.yml
@@ -27,6 +27,7 @@ version: '3.4'
 x-common-env-variables: &common-variables
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
+  Clients_Data_Host: edgex-core-data # For device Services
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -66,9 +67,7 @@ services:
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     networks:
-      edgex-network:
-        aliases:
-            - edgex-core-consul
+      - edgex-network
     volumes:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
@@ -89,9 +88,7 @@ services:
     container_name: edgex-vault
     hostname: edgex-vault
     networks:
-      edgex-network:
-        aliases:
-            - edgex-vault
+      - edgex-network
     ports:
       - "127.0.0.1:8200:8200"
     cap_add:
@@ -113,7 +110,7 @@ services:
       - security-secrets-setup
 
   security-secrets-setup:
-    image: edgexfoundry/docker-edgex-secrets-setup-go:1.2.0
+    image: edgexfoundry/docker-edgex-secrets-setup-go:1.2.1
     container_name: edgex-secrets-setup
     hostname: edgex-secrets-setup
     tmpfs:
@@ -126,15 +123,13 @@ services:
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
 
   vault-worker:
-    image: edgexfoundry/docker-edgex-security-secretstore-setup-go:1.2.0
+    image: edgexfoundry/docker-edgex-security-secretstore-setup-go:1.2.1
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
     environment:
       - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
     networks:
-      edgex-network:
-        aliases:
-            - edgex-vault-worker
+      - edgex-network
     tmpfs:
       - /run
     volumes:
@@ -152,9 +147,7 @@ services:
     container_name: kong-db
     hostname: kong-db
     networks:
-      edgex-network:
-        aliases:
-            - kong-db
+      - edgex-network
     ports:
         - "127.0.0.1:5432:5432"
     environment:
@@ -168,9 +161,7 @@ services:
     image: kong:${KONG_VERSION:-2.0.1}
     container_name: kong-migrations
     networks:
-      edgex-network:
-        aliases:
-            - kong-migrations
+      - edgex-network
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
@@ -196,9 +187,7 @@ services:
     container_name: kong
     hostname: kong
     networks:
-      edgex-network:
-        aliases:
-            - kong
+      - edgex-network
     ports:
         - "8000:8000"
         - "127.0.0.1:8001:8001"
@@ -227,7 +216,7 @@ services:
       - kong-migrations
 
   edgex-proxy:
-    image: edgexfoundry/docker-edgex-security-proxy-setup-go:1.2.0
+    image: edgexfoundry/docker-edgex-security-proxy-setup-go:1.2.1
     container_name: edgex-proxy
     hostname: edgex-proxy
     entrypoint: >
@@ -236,9 +225,7 @@ services:
       until /consul/scripts/consul-svc-healthy.sh security-secretstore-setup; do sleep 1; done;
       /edgex/security-proxy-setup --init=true"
     networks:
-      edgex-network:
-        aliases:
-            - edgex-proxy
+      - edgex-network
     environment:
       <<: *common-variables
       KongURL_Server: kong
@@ -286,7 +273,7 @@ services:
 # and the related global override that are commented out at the top.
 #  
 #  logging:
-#    image: edgexfoundry/docker-support-logging-go:1.2.0
+#    image: edgexfoundry/docker-support-logging-go:1.2.1
 #    ports:
 #      - "127.0.0.1:48061:48061"
 #    container_name: edgex-support-logging
@@ -308,7 +295,7 @@ services:
 #      - vault-worker
 
   system:
-    image: edgexfoundry/docker-sys-mgmt-agent-go:1.2.0
+    image: edgexfoundry/docker-sys-mgmt-agent-go:1.2.1
     ports:
       - "127.0.0.1:48090:48090"
     container_name: edgex-sys-mgmt-agent
@@ -332,7 +319,7 @@ services:
       - command
 
   notifications:
-    image: edgexfoundry/docker-support-notifications-go:1.2.0
+    image: edgexfoundry/docker-support-notifications-go:1.2.1
     ports:
       - "127.0.0.1:48060:48060"
     container_name: edgex-support-notifications
@@ -353,7 +340,7 @@ services:
       - vault-worker
 
   metadata:
-    image: edgexfoundry/docker-core-metadata-go:1.2.0
+    image: edgexfoundry/docker-core-metadata-go:1.2.1
     ports:
       - "127.0.0.1:48081:48081"
     container_name: edgex-core-metadata
@@ -376,7 +363,7 @@ services:
       - vault-worker
 
   data:
-    image: edgexfoundry/docker-core-data-go:1.2.0
+    image: edgexfoundry/docker-core-data-go:1.2.1
     ports:
       - "127.0.0.1:48080:48080"
       - "127.0.0.1:5563:5563"
@@ -399,7 +386,7 @@ services:
       - vault-worker
 
   command:
-    image: edgexfoundry/docker-core-command-go:1.2.0
+    image: edgexfoundry/docker-core-command-go:1.2.1
     ports:
       - "127.0.0.1:48082:48082"
     container_name: edgex-core-command
@@ -421,7 +408,7 @@ services:
       - vault-worker
 
   scheduler:
-    image: edgexfoundry/docker-support-scheduler-go:1.2.0
+    image: edgexfoundry/docker-support-scheduler-go:1.2.1
     ports:
       - "127.0.0.1:48085:48085"
     container_name: edgex-support-scheduler
@@ -444,15 +431,13 @@ services:
       - vault-worker
 
   app-service-rules:
-    image: edgexfoundry/docker-app-service-configurable:1.1.0
+    image: edgexfoundry/docker-app-service-configurable:1.2.0
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
     networks:
-      edgex-network:
-        aliases:
-          - edgex-app-service-configurable-rules
+      - edgex-network
     environment:
       <<: *common-variables
       EDGEX_SECURITY_SECRET_STORE: "false" # required since SecretStore not used and not configured
@@ -468,16 +453,14 @@ services:
       - vault-worker
 
   rulesengine:
-    image: emqx/kuiper:0.3.2
+    image: emqx/kuiper:0.4.2
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"
     container_name: edgex-kuiper
     hostname: edgex-kuiper
     networks:
-      edgex-network:
-        aliases:
-          - edgex-kuiper
+      - edgex-network
     environment:
       # KUIPER_DEBUG: "true"
       KUIPER_CONSOLE_LOG: "true"
@@ -494,15 +477,13 @@ services:
   # If still required, simply uncomment the block below and comment out the block above.
   #
   # rulesengine:
-  #   image: edgexfoundry/docker-support-rulesengine:1.2.0
+  #   image: edgexfoundry/docker-support-rulesengine:1.2.1
   #   ports:
   #     - "127.0.0.1:48075:48075"
   #   container_name: edgex-support-rulesengine
   #   hostname: edgex-support-rulesengine
   #   networks:
-  #     edgex-network:
-  #       aliases:
-  #         - edgex-support-rulesengine
+  #     - edgex-network
   #   depends_on:
   #     - app-service-rules
 
@@ -511,18 +492,17 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go:1.2.0
+    image: edgexfoundry/docker-device-virtual-go:1.2.1
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual
     hostname: edgex-device-virtual
     networks:
-      edgex-network:
-        aliases:
-        - edgex-device-virtual
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
+      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -530,90 +510,84 @@ services:
       - metadata
 
   device-rest:
-    image: edgexfoundry/docker-device-rest-go:1.1.0
+    image: edgexfoundry/docker-device-rest-go:1.1.1
     ports:
       - "127.0.0.1:49986:49986"
     container_name: edgex-device-rest
     hostname: edgex-device-rest
     networks:
-      edgex-network:
-        aliases:
-          - edgex-device-rest
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
+      Service_Timeout: "20000"
     depends_on:
       - data
       - command
   #      - logging  # uncomment if re-enabled remote logging
 
-  # device-random:
-  #   image: edgexfoundry/docker-device-random-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49988:49988"
-  #   container_name: edgex-device-random
-  #   hostname: edgex-device-random
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-random
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-random
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-mqtt:
-  #   image: edgexfoundry/docker-device-mqtt-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49982:49982"
-  #   container_name: edgex-device-mqtt
-  #   hostname: edgex-device-mqtt
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-mqtt
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-mqtt
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-modbus:
-  #   image: edgexfoundry/docker-device-modbus-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49991:49991"
-  #   container_name: edgex-device-modbus
-  #   hostname: edgex-device-modbus
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-modbus
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-modbus
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-snmp:
-  #   image: edgexfoundry/docker-device-snmp-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49993:49993"
-  #   container_name: edgex-device-snmp
-  #   hostname: edgex-device-snmp
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-snmp
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-snmp
-  #   depends_on:
-  #     - data
-  #     - command
+#  device-random:
+#    image: edgexfoundry/docker-device-random-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49988:49988"
+#    container_name: edgex-device-random
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-random
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-mqtt:
+#    image: edgexfoundry/docker-device-mqtt-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49982:49982"
+#    container_name: edgex-device-mqtt
+#    hostname: edgex-device-mqtt
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-mqtt
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-modbus:
+#    image: edgexfoundry/docker-device-modbus-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49991:49991"
+#    container_name: edgex-device-modbus
+#    hostname: edgex-device-modbus
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-modbus
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-snmp:
+#    image: edgexfoundry/docker-device-snmp-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49993:49993"
+#    container_name: edgex-device-snmp
+#    hostname: edgex-device-snmp
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-snmp
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
 
 networks:
   edgex-network:

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo.yml
@@ -454,7 +454,7 @@ services:
       - vault-worker
 
   rulesengine:
-    image: emqx/kuiper:0.4.2
+    image: emqx/kuiper:0.4.2-alpine
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-arm64.yml
@@ -511,7 +511,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
-      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -529,7 +528,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
-      Service_Timeout: "20000"
     depends_on:
       - data
       - command
@@ -546,7 +544,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-random
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -562,7 +559,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-mqtt
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -578,7 +574,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-modbus
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -594,7 +589,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-snmp
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-arm64.yml
@@ -358,6 +358,7 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-core-metadata
+      Service_Timeout: "20000"
       Notifications_Sender: edgex-core-metadata
       SecretStore_TokenFile: /tmp/edgex/secrets/edgex-core-metadata/secrets-token.json
     volumes:

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-arm64.yml
@@ -462,7 +462,7 @@ services:
       - vault-worker
 
   rulesengine:
-    image: emqx/kuiper:0.4.2
+    image: emqx/kuiper:0.4.2-alpine
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-arm64.yml
@@ -24,6 +24,7 @@ version: '3.4'
 x-common-env-variables: &common-variables
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
+  Clients_Data_Host: edgex-core-data # For device Services
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -69,9 +70,7 @@ services:
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     networks:
-      edgex-network:
-        aliases:
-            - edgex-core-consul
+      - edgex-network
     volumes:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
@@ -92,9 +91,7 @@ services:
     container_name: edgex-vault
     hostname: edgex-vault
     networks:
-      edgex-network:
-        aliases:
-            - edgex-vault
+      - edgex-network
     ports:
       - "127.0.0.1:8200:8200"
     cap_add:
@@ -116,7 +113,7 @@ services:
       - security-secrets-setup
 
   security-secrets-setup:
-    image: edgexfoundry/docker-edgex-secrets-setup-go-arm64:1.2.0
+    image: edgexfoundry/docker-edgex-secrets-setup-go-arm64:1.2.1
     container_name: edgex-secrets-setup
     hostname: edgex-secrets-setup
     environment:
@@ -131,16 +128,14 @@ services:
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
 
   vault-worker:
-    image: edgexfoundry/docker-edgex-security-secretstore-setup-go-arm64:1.2.0
+    image: edgexfoundry/docker-edgex-security-secretstore-setup-go-arm64:1.2.1
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
     environment:
       <<: *redis5-variables
       SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
     networks:
-      edgex-network:
-        aliases:
-            - edgex-vault-worker
+      - edgex-network
     tmpfs:
       - /run
     volumes:
@@ -158,9 +153,7 @@ services:
     container_name: kong-db
     hostname: kong-db
     networks:
-      edgex-network:
-        aliases:
-            - kong-db
+      - edgex-network
     ports:
         - "127.0.0.1:5432:5432"
     environment:
@@ -174,9 +167,7 @@ services:
     image: kong:${KONG_VERSION:-2.0.1}-ubuntu
     container_name: kong-migrations
     networks:
-      edgex-network:
-        aliases:
-            - kong-migrations
+      - edgex-network
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
@@ -202,9 +193,7 @@ services:
     container_name: kong
     hostname: kong
     networks:
-      edgex-network:
-        aliases:
-            - kong
+      - edgex-network
     ports:
         - "8000:8000"
         - "127.0.0.1:8001:8001"
@@ -233,7 +222,7 @@ services:
       - kong-migrations
 
   edgex-proxy:
-    image: edgexfoundry/docker-edgex-security-proxy-setup-go-arm64:1.2.0
+    image: edgexfoundry/docker-edgex-security-proxy-setup-go-arm64:1.2.1
     container_name: edgex-proxy
     hostname: edgex-proxy
     entrypoint: >
@@ -242,9 +231,7 @@ services:
       until /consul/scripts/consul-svc-healthy.sh security-secretstore-setup; do sleep 1; done;
       /edgex/security-proxy-setup --init=true"
     networks:
-      edgex-network:
-        aliases:
-            - edgex-proxy
+      - edgex-network
     environment:
       <<: *common-variables
       KongURL_Server: kong
@@ -294,7 +281,7 @@ services:
 # and the related global override that are commented out at the top.
 #
 #  logging:
-#    image: edgexfoundry/docker-support-logging-go-arm64:1.2.0
+#    image: edgexfoundry/docker-support-logging-go-arm64:1.2.1
 #    ports:
 #      - "127.0.0.1:48061:48061"
 #    container_name: edgex-support-logging
@@ -316,7 +303,7 @@ services:
 #      - vault-worker
 
   system:
-    image: edgexfoundry/docker-sys-mgmt-agent-go-arm64:1.2.0
+    image: edgexfoundry/docker-sys-mgmt-agent-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48090:48090"
     container_name: edgex-sys-mgmt-agent
@@ -340,7 +327,7 @@ services:
       - command
 
   notifications:
-    image: edgexfoundry/docker-support-notifications-go-arm64:1.2.0
+    image: edgexfoundry/docker-support-notifications-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48060:48060"
     container_name: edgex-support-notifications
@@ -361,7 +348,7 @@ services:
       - vault-worker
 
   metadata:
-    image: edgexfoundry/docker-core-metadata-go-arm64:1.2.0
+    image: edgexfoundry/docker-core-metadata-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48081:48081"
     container_name: edgex-core-metadata
@@ -384,7 +371,7 @@ services:
       - vault-worker
 
   data:
-    image: edgexfoundry/docker-core-data-go-arm64:1.2.0
+    image: edgexfoundry/docker-core-data-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48080:48080"
       - "127.0.0.1:5563:5563"
@@ -407,7 +394,7 @@ services:
       - vault-worker
 
   command:
-    image: edgexfoundry/docker-core-command-go-arm64:1.2.0
+    image: edgexfoundry/docker-core-command-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48082:48082"
     container_name: edgex-core-command
@@ -429,7 +416,7 @@ services:
       - vault-worker
 
   scheduler:
-    image: edgexfoundry/docker-support-scheduler-go-arm64:1.2.0
+    image: edgexfoundry/docker-support-scheduler-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48085:48085"
     container_name: edgex-support-scheduler
@@ -452,15 +439,13 @@ services:
       - vault-worker
 
   app-service-rules:
-    image: edgexfoundry/docker-app-service-configurable-arm64:1.1.0
+    image: edgexfoundry/docker-app-service-configurable-arm64:1.2.0
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
     networks:
-      edgex-network:
-        aliases:
-          - edgex-app-service-configurable-rules
+      - edgex-network
     environment:
       <<: *common-variables
       EDGEX_SECURITY_SECRET_STORE: "false" # required since SecretStore not used and not configured
@@ -476,16 +461,14 @@ services:
       - vault-worker
 
   rulesengine:
-    image: emqx/kuiper:0.3.2
+    image: emqx/kuiper:0.4.2
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"
     container_name: edgex-kuiper
     hostname: edgex-kuiper
     networks:
-      edgex-network:
-        aliases:
-          - edgex-kuiper
+      - edgex-network
     environment:
       # KUIPER_DEBUG: "true"
       KUIPER_CONSOLE_LOG: "true"
@@ -502,15 +485,13 @@ services:
   # If still required, simply uncomment the block below and comment out the block above.
   #
   # rulesengine:
-  #   image: edgexfoundry/docker-support-rulesengine-arm64:1.2.0
+  #   image: edgexfoundry/docker-support-rulesengine-arm64:1.2.1
   #   ports:
   #     - "127.0.0.1:48075:48075"
   #   container_name: edgex-support-rulesengine
   #   hostname: edgex-support-rulesengine
   #   networks:
-  #     edgex-network:
-  #       aliases:
-  #         - edgex-support-rulesengine
+  #     - edgex-network
   #   depends_on:
   #     - app-service-rules
 
@@ -519,18 +500,17 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.0
+    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.1
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual
     hostname: edgex-device-virtual
     networks:
-      edgex-network:
-        aliases:
-        - edgex-device-virtual
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
+      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -538,90 +518,85 @@ services:
       - metadata
 
   device-rest:
-    image: edgexfoundry/docker-device-rest-go-arm64:1.1.0
+    image: edgexfoundry/docker-device-rest-go-arm64:1.1.1
     ports:
       - "127.0.0.1:49986:49986"
     container_name: edgex-device-rest
     hostname: edgex-device-rest
     networks:
-      edgex-network:
-        aliases:
-          - edgex-device-rest
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
+      Service_Timeout: "20000"
     depends_on:
       - data
       - command
   #      - logging  # uncomment if re-enabled remote logging
 
-  # device-random:
-  #   image: edgexfoundry/docker-device-random-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49988:49988"
-  #   container_name: edgex-device-random
-  #   hostname: edgex-device-random
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-random
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-random
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-mqtt:
-  #   image: edgexfoundry/docker-device-mqtt-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49982:49982"
-  #   container_name: edgex-device-mqtt
-  #   hostname: edgex-device-mqtt
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-mqtt
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-mqtt
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-modbus:
-  #   image: edgexfoundry/docker-device-modbus-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49991:49991"
-  #   container_name: edgex-device-modbus
-  #   hostname: edgex-device-modbus
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-modbus
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-modbus
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-snmp:
-  #   image: edgexfoundry/docker-device-snmp-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49993:49993"
-  #   container_name: edgex-device-snmp
-  #   hostname: edgex-device-snmp
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-snmp
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-snmp
-  #   depends_on:
-  #     - data
-  #     - command
+#  device-random:
+#    image: edgexfoundry/docker-device-random-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49988:49988"
+#    container_name: edgex-device-random
+#    hostname: edgex-device-random
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-random
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-mqtt:
+#    image: edgexfoundry/docker-device-mqtt-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49982:49982"
+#    container_name: edgex-device-mqtt
+#    hostname: edgex-device-mqtt
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-mqtt
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-modbus:
+#    image: edgexfoundry/docker-device-modbus-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49991:49991"
+#    container_name: edgex-device-modbus
+#    hostname: edgex-device-modbus
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-modbus
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-snmp:
+#    image: edgexfoundry/docker-device-snmp-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49993:49993"
+#    container_name: edgex-device-snmp
+#    hostname: edgex-device-snmp
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-snmp
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
 
 networks:
   edgex-network:

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty-arm64.yml
@@ -29,6 +29,7 @@ x-common-env-variables: &common-variables
   EDGEX_SECURITY_SECRET_STORE: "false"
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
+  Clients_Data_Host: edgex-core-data # For device Services
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -56,9 +57,7 @@ services:
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     networks:
-      edgex-network:
-        aliases:
-            - edgex-core-consul
+      - edgex-network
     volumes:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
@@ -85,7 +84,7 @@ services:
 # and the related global override that are commented out at the top.
 #
 #  logging:
-#    image: edgexfoundry/docker-support-logging-go-arm64:1.2.0
+#    image: edgexfoundry/docker-support-logging-go-arm64:1.2.1
 #    ports:
 #      - "127.0.0.1:48061:48061"
 #    container_name: edgex-support-logging
@@ -102,7 +101,7 @@ services:
 #      - consul
 
   system:
-    image: edgexfoundry/docker-sys-mgmt-agent-go-arm64:1.2.0
+    image: edgexfoundry/docker-sys-mgmt-agent-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48090:48090"
     container_name: edgex-sys-mgmt-agent
@@ -126,7 +125,7 @@ services:
       - command
 
   notifications:
-    image: edgexfoundry/docker-support-notifications-go-arm64:1.2.0
+    image: edgexfoundry/docker-support-notifications-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48060:48060"
     container_name: edgex-support-notifications
@@ -142,7 +141,7 @@ services:
       - redis
 
   metadata:
-    image: edgexfoundry/docker-core-metadata-go-arm64:1.2.0
+    image: edgexfoundry/docker-core-metadata-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48081:48081"
     container_name: edgex-core-metadata
@@ -160,7 +159,7 @@ services:
       - notifications
 
   data:
-    image: edgexfoundry/docker-core-data-go-arm64:1.2.0
+    image: edgexfoundry/docker-core-data-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48080:48080"
       - "127.0.0.1:5563:5563"
@@ -178,7 +177,7 @@ services:
       - metadata
 
   command:
-    image: edgexfoundry/docker-core-command-go-arm64:1.2.0
+    image: edgexfoundry/docker-core-command-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48082:48082"
     container_name: edgex-core-command
@@ -195,7 +194,7 @@ services:
       - metadata
 
   scheduler:
-    image: edgexfoundry/docker-support-scheduler-go-arm64:1.2.0
+    image: edgexfoundry/docker-support-scheduler-go-arm64:1.2.1
     ports:
       - "127.0.0.1:48085:48085"
     container_name: edgex-support-scheduler
@@ -213,15 +212,13 @@ services:
       - redis
 
   app-service-rules:
-    image: edgexfoundry/docker-app-service-configurable-arm64:1.1.0
+    image: edgexfoundry/docker-app-service-configurable-arm64:1.2.0
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
     networks:
-      edgex-network:
-        aliases:
-          - edgex-app-service-configurable-rules
+      - edgex-network
     environment:
       <<: *common-variables
       edgex_profile: rules-engine
@@ -235,16 +232,14 @@ services:
       - data
 
   rulesengine:
-    image: emqx/kuiper:0.3.2
+    image: emqx/kuiper:0.4.2
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"
     container_name: edgex-kuiper
     hostname: edgex-kuiper
     networks:
-      edgex-network:
-        aliases:
-          - edgex-kuiper
+      - edgex-network
     environment:
       # KUIPER_DEBUG: "true"
       KUIPER_CONSOLE_LOG: "true"
@@ -261,15 +256,13 @@ services:
   # If still required, simply uncomment the block below and comment out the block above.
   #
   # rulesengine:
-  #   image: edgexfoundry/docker-support-rulesengine-arm64:1.2.0
+  #   image: edgexfoundry/docker-support-rulesengine-arm64:1.2.1
   #   ports:
   #     - "127.0.0.1:48075:48075"
   #   container_name: edgex-support-rulesengine
   #   hostname: edgex-support-rulesengine
   #   networks:
-  #     edgex-network:
-  #       aliases:
-  #         - edgex-support-rulesengine
+  #     - edgex-network
   #   depends_on:
   #     - app-service-rules
 
@@ -278,18 +271,17 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.0
+    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.1
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual
     hostname: edgex-device-virtual
     networks:
-      edgex-network:
-        aliases:
-        - edgex-device-virtual
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
+      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -297,90 +289,85 @@ services:
       - metadata
 
   device-rest:
-    image: edgexfoundry/docker-device-rest-go-arm64:1.1.0
+    image: edgexfoundry/docker-device-rest-go-arm64:1.1.1
     ports:
       - "127.0.0.1:49986:49986"
     container_name: edgex-device-rest
     hostname: edgex-device-rest
     networks:
-      edgex-network:
-        aliases:
-          - edgex-device-rest
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
+      Service_Timeout: "20000"
     depends_on:
       - data
       - command
   #      - logging  # uncomment if re-enabled remote logging
 
-  # device-random:
-  #   image: edgexfoundry/docker-device-random-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49988:49988"
-  #   container_name: edgex-device-random
-  #   hostname: edgex-device-random
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-random
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-random
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-mqtt:
-  #   image: edgexfoundry/docker-device-mqtt-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49982:49982"
-  #   container_name: edgex-device-mqtt
-  #   hostname: edgex-device-mqtt
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-mqtt
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-mqtt
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-modbus:
-  #   image: edgexfoundry/docker-device-modbus-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49991:49991"
-  #   container_name: edgex-device-modbus
-  #   hostname: edgex-device-modbus
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-modbus
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-modbus
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-snmp:
-  #   image: edgexfoundry/docker-device-snmp-go-arm64:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49993:49993"
-  #   container_name: edgex-device-snmp
-  #   hostname: edgex-device-snmp
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-snmp
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-snmp
-  #   depends_on:
-  #     - data
-  #     - command
+#  device-random:
+#    image: edgexfoundry/docker-device-random-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49988:49988"
+#    container_name: edgex-device-random
+#    hostname: edgex-device-random
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-random
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-mqtt:
+#    image: edgexfoundry/docker-device-mqtt-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49982:49982"
+#    container_name: edgex-device-mqtt
+#    hostname: edgex-device-mqtt
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-mqtt
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-modbus:
+#    image: edgexfoundry/docker-device-modbus-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49991:49991"
+#    container_name: edgex-device-modbus
+#    hostname: edgex-device-modbus
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-modbus
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-snmp:
+#    image: edgexfoundry/docker-device-snmp-go-arm64:1.2.1
+#    ports:
+#      - "127.0.0.1:49993:49993"
+#    container_name: edgex-device-snmp
+#    hostname: edgex-device-snmp
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-snmp
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
 
 networks:
   edgex-network:

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty-arm64.yml
@@ -233,7 +233,7 @@ services:
       - data
 
   rulesengine:
-    image: emqx/kuiper:0.4.2
+    image: emqx/kuiper:0.4.2-alpine-alpine
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty-arm64.yml
@@ -233,7 +233,7 @@ services:
       - data
 
   rulesengine:
-    image: emqx/kuiper:0.4.2-alpine-alpine
+    image: emqx/kuiper:0.4.2-alpine
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty-arm64.yml
@@ -282,7 +282,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
-      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -300,7 +299,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
-      Service_Timeout: "20000"
     depends_on:
       - data
       - command
@@ -317,7 +315,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-random
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -333,7 +330,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-mqtt
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -349,7 +345,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-modbus
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -365,7 +360,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-snmp
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty-arm64.yml
@@ -151,6 +151,7 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-core-metadata
+      Service_Timeout: "20000"
       Notifications_Sender: edgex-core-metadata
     depends_on:
       - consul

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty.yml
@@ -29,6 +29,7 @@ x-common-env-variables: &common-variables
   EDGEX_SECURITY_SECRET_STORE: "false"
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
+  Clients_Data_Host: edgex-core-data # For device Services
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -56,9 +57,7 @@ services:
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     networks:
-      edgex-network:
-        aliases:
-            - edgex-core-consul
+      - edgex-network
     volumes:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
@@ -85,7 +84,7 @@ services:
 # and the related global override that are commented out at the top.
 #
 #  logging:
-#    image: edgexfoundry/docker-support-logging-go:1.2.0
+#    image: edgexfoundry/docker-support-logging-go:1.2.1
 #    ports:
 #      - "127.0.0.1:48061:48061"
 #    container_name: edgex-support-logging
@@ -102,7 +101,7 @@ services:
 #      - consul
 
   system:
-    image: edgexfoundry/docker-sys-mgmt-agent-go:1.2.0
+    image: edgexfoundry/docker-sys-mgmt-agent-go:1.2.1
     ports:
       - "127.0.0.1:48090:48090"
     container_name: edgex-sys-mgmt-agent
@@ -126,7 +125,7 @@ services:
       - command
 
   notifications:
-    image: edgexfoundry/docker-support-notifications-go:1.2.0
+    image: edgexfoundry/docker-support-notifications-go:1.2.1
     ports:
       - "127.0.0.1:48060:48060"
     container_name: edgex-support-notifications
@@ -142,7 +141,7 @@ services:
       - redis
 
   metadata:
-    image: edgexfoundry/docker-core-metadata-go:1.2.0
+    image: edgexfoundry/docker-core-metadata-go:1.2.1
     ports:
       - "127.0.0.1:48081:48081"
     container_name: edgex-core-metadata
@@ -160,7 +159,7 @@ services:
       - notifications
 
   data:
-    image: edgexfoundry/docker-core-data-go:1.2.0
+    image: edgexfoundry/docker-core-data-go:1.2.1
     ports:
       - "127.0.0.1:48080:48080"
       - "127.0.0.1:5563:5563"
@@ -178,7 +177,7 @@ services:
       - metadata
 
   command:
-    image: edgexfoundry/docker-core-command-go:1.2.0
+    image: edgexfoundry/docker-core-command-go:1.2.1
     ports:
       - "127.0.0.1:48082:48082"
     container_name: edgex-core-command
@@ -195,7 +194,7 @@ services:
       - metadata
 
   scheduler:
-    image: edgexfoundry/docker-support-scheduler-go:1.2.0
+    image: edgexfoundry/docker-support-scheduler-go:1.2.1
     ports:
       - "127.0.0.1:48085:48085"
     container_name: edgex-support-scheduler
@@ -213,15 +212,13 @@ services:
       - redis
 
   app-service-rules:
-    image: edgexfoundry/docker-app-service-configurable:1.1.0
+    image: edgexfoundry/docker-app-service-configurable:1.2.0
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
     networks:
-      edgex-network:
-        aliases:
-          - edgex-app-service-configurable-rules
+      - edgex-network
     environment:
       <<: *common-variables
       edgex_profile: rules-engine
@@ -235,16 +232,14 @@ services:
       - data
 
   rulesengine:
-    image: emqx/kuiper:0.3.2
+    image: emqx/kuiper:0.4.2
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"
     container_name: edgex-kuiper
     hostname: edgex-kuiper
     networks:
-      edgex-network:
-        aliases:
-          - edgex-kuiper
+      - edgex-network
     environment:
       # KUIPER_DEBUG: "true"
       KUIPER_CONSOLE_LOG: "true"
@@ -261,15 +256,13 @@ services:
   # If still required, simply uncomment the block below and comment out the block above.
   #
   # rulesengine:
-  #   image: edgexfoundry/docker-support-rulesengine:1.2.0
+  #   image: edgexfoundry/docker-support-rulesengine:1.2.1
   #   ports:
   #     - "127.0.0.1:48075:48075"
   #   container_name: edgex-support-rulesengine
   #   hostname: edgex-support-rulesengine
   #   networks:
-  #     edgex-network:
-  #       aliases:
-  #         - edgex-support-rulesengine
+  #     - edgex-network
   #   depends_on:
   #     - app-service-rules
 
@@ -278,18 +271,17 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go:1.2.0
+    image: edgexfoundry/docker-device-virtual-go:1.2.1
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual
     hostname: edgex-device-virtual
     networks:
-      edgex-network:
-        aliases:
-        - edgex-device-virtual
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
+      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -297,90 +289,85 @@ services:
       - metadata
 
   device-rest:
-    image: edgexfoundry/docker-device-rest-go:1.1.0
+    image: edgexfoundry/docker-device-rest-go:1.1.1
     ports:
       - "127.0.0.1:49986:49986"
     container_name: edgex-device-rest
     hostname: edgex-device-rest
     networks:
-      edgex-network:
-        aliases:
-          - edgex-device-rest
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
+      Service_Timeout: "20000"
     depends_on:
       - data
       - command
   #      - logging  # uncomment if re-enabled remote logging
 
-  # device-random:
-  #   image: edgexfoundry/docker-device-random-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49988:49988"
-  #   container_name: edgex-device-random
-  #   hostname: edgex-device-random
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-random
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-random
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-mqtt:
-  #   image: edgexfoundry/docker-device-mqtt-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49982:49982"
-  #   container_name: edgex-device-mqtt
-  #   hostname: edgex-device-mqtt
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-mqtt
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-mqtt
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-modbus:
-  #   image: edgexfoundry/docker-device-modbus-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49991:49991"
-  #   container_name: edgex-device-modbus
-  #   hostname: edgex-device-modbus
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-modbus
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-modbus
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-snmp:
-  #   image: edgexfoundry/docker-device-snmp-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49993:49993"
-  #   container_name: edgex-device-snmp
-  #   hostname: edgex-device-snmp
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-snmp
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-snmp
-  #   depends_on:
-  #     - data
-  #     - command
+#  device-random:
+#    image: edgexfoundry/docker-device-random-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49988:49988"
+#    container_name: edgex-device-random
+#    hostname: edgex-device-random
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-random
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-mqtt:
+#    image: edgexfoundry/docker-device-mqtt-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49982:49982"
+#    container_name: edgex-device-mqtt
+#    hostname: edgex-device-mqtt
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-mqtt
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-modbus:
+#    image: edgexfoundry/docker-device-modbus-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49991:49991"
+#    container_name: edgex-device-modbus
+#    hostname: edgex-device-modbus
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-modbus
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-snmp:
+#    image: edgexfoundry/docker-device-snmp-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49993:49993"
+#    container_name: edgex-device-snmp
+#    hostname: edgex-device-snmp
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-snmp
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
 
 networks:
   edgex-network:

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty.yml
@@ -282,7 +282,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
-      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -300,7 +299,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
-      Service_Timeout: "20000"
     depends_on:
       - data
       - command
@@ -317,7 +315,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-random
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -333,7 +330,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-mqtt
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -349,7 +345,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-modbus
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -365,7 +360,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-snmp
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty.yml
@@ -233,7 +233,7 @@ services:
       - data
 
   rulesengine:
-    image: emqx/kuiper:0.4.2
+    image: emqx/kuiper:0.4.2-alpine
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty.yml
@@ -151,6 +151,7 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-core-metadata
+      Service_Timeout: "20000"
       Notifications_Sender: edgex-core-metadata
     depends_on:
       - consul

--- a/releases/geneva/compose-files/docker-compose-geneva-redis.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis.yml
@@ -24,6 +24,7 @@ version: '3.4'
 x-common-env-variables: &common-variables
   Registry_Host: edgex-core-consul
   Clients_CoreData_Host: edgex-core-data
+  Clients_Data_Host: edgex-core-data # For device Services
   Clients_Notifications_Host: edgex-support-notifications
   Clients_Metadata_Host: edgex-core-metadata
   Clients_Command_Host: edgex-core-command
@@ -69,9 +70,7 @@ services:
     container_name: edgex-core-consul
     hostname: edgex-core-consul
     networks:
-      edgex-network:
-        aliases:
-            - edgex-core-consul
+      - edgex-network
     volumes:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
@@ -92,9 +91,7 @@ services:
     container_name: edgex-vault
     hostname: edgex-vault
     networks:
-      edgex-network:
-        aliases:
-            - edgex-vault
+      - edgex-network
     ports:
       - "127.0.0.1:8200:8200"
     cap_add:
@@ -116,7 +113,7 @@ services:
       - security-secrets-setup
 
   security-secrets-setup:
-    image: edgexfoundry/docker-edgex-secrets-setup-go:1.2.0
+    image: edgexfoundry/docker-edgex-secrets-setup-go:1.2.1
     container_name: edgex-secrets-setup
     hostname: edgex-secrets-setup
     environment:
@@ -131,16 +128,14 @@ services:
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
 
   vault-worker:
-    image: edgexfoundry/docker-edgex-security-secretstore-setup-go:1.2.0
+    image: edgexfoundry/docker-edgex-security-secretstore-setup-go:1.2.1
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
     environment:
       <<: *redis5-variables
       SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
     networks:
-      edgex-network:
-        aliases:
-            - edgex-vault-worker
+      - edgex-network
     tmpfs:
       - /run
     volumes:
@@ -158,9 +153,7 @@ services:
     container_name: kong-db
     hostname: kong-db
     networks:
-      edgex-network:
-        aliases:
-            - kong-db
+      - edgex-network
     ports:
         - "127.0.0.1:5432:5432"
     environment:
@@ -174,9 +167,7 @@ services:
     image: kong:${KONG_VERSION:-2.0.1}
     container_name: kong-migrations
     networks:
-      edgex-network:
-        aliases:
-            - kong-migrations
+      - edgex-network
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
@@ -202,9 +193,7 @@ services:
     container_name: kong
     hostname: kong
     networks:
-      edgex-network:
-        aliases:
-            - kong
+      - edgex-network
     ports:
         - "8000:8000"
         - "127.0.0.1:8001:8001"
@@ -233,7 +222,7 @@ services:
       - kong-migrations
 
   edgex-proxy:
-    image: edgexfoundry/docker-edgex-security-proxy-setup-go:1.2.0
+    image: edgexfoundry/docker-edgex-security-proxy-setup-go:1.2.1
     container_name: edgex-proxy
     hostname: edgex-proxy
     entrypoint: >
@@ -242,9 +231,7 @@ services:
       until /consul/scripts/consul-svc-healthy.sh security-secretstore-setup; do sleep 1; done;
       /edgex/security-proxy-setup --init=true"
     networks:
-      edgex-network:
-        aliases:
-            - edgex-proxy
+      - edgex-network
     environment:
       <<: *common-variables
       KongURL_Server: kong
@@ -294,7 +281,7 @@ services:
 # and the related global override that are commented out at the top.
 #
 #  logging:
-#    image: edgexfoundry/docker-support-logging-go:1.2.0
+#    image: edgexfoundry/docker-support-logging-go:1.2.1
 #    ports:
 #      - "127.0.0.1:48061:48061"
 #    container_name: edgex-support-logging
@@ -316,7 +303,7 @@ services:
 #      - vault-worker
 
   system:
-    image: edgexfoundry/docker-sys-mgmt-agent-go:1.2.0
+    image: edgexfoundry/docker-sys-mgmt-agent-go:1.2.1
     ports:
       - "127.0.0.1:48090:48090"
     container_name: edgex-sys-mgmt-agent
@@ -340,7 +327,7 @@ services:
       - command
 
   notifications:
-    image: edgexfoundry/docker-support-notifications-go:1.2.0
+    image: edgexfoundry/docker-support-notifications-go:1.2.1
     ports:
       - "127.0.0.1:48060:48060"
     container_name: edgex-support-notifications
@@ -361,7 +348,7 @@ services:
       - vault-worker
 
   metadata:
-    image: edgexfoundry/docker-core-metadata-go:1.2.0
+    image: edgexfoundry/docker-core-metadata-go:1.2.1
     ports:
       - "127.0.0.1:48081:48081"
     container_name: edgex-core-metadata
@@ -384,7 +371,7 @@ services:
       - vault-worker
 
   data:
-    image: edgexfoundry/docker-core-data-go:1.2.0
+    image: edgexfoundry/docker-core-data-go:1.2.1
     ports:
       - "127.0.0.1:48080:48080"
       - "127.0.0.1:5563:5563"
@@ -407,7 +394,7 @@ services:
       - vault-worker
 
   command:
-    image: edgexfoundry/docker-core-command-go:1.2.0
+    image: edgexfoundry/docker-core-command-go:1.2.1
     ports:
       - "127.0.0.1:48082:48082"
     container_name: edgex-core-command
@@ -429,7 +416,7 @@ services:
       - vault-worker
 
   scheduler:
-    image: edgexfoundry/docker-support-scheduler-go:1.2.0
+    image: edgexfoundry/docker-support-scheduler-go:1.2.1
     ports:
       - "127.0.0.1:48085:48085"
     container_name: edgex-support-scheduler
@@ -452,15 +439,13 @@ services:
       - vault-worker
 
   app-service-rules:
-    image: edgexfoundry/docker-app-service-configurable:1.1.0
+    image: edgexfoundry/docker-app-service-configurable:1.2.0
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
     networks:
-      edgex-network:
-        aliases:
-          - edgex-app-service-configurable-rules
+      - edgex-network
     environment:
       <<: *common-variables
       EDGEX_SECURITY_SECRET_STORE: "false" # required since SecretStore not used and not configured
@@ -476,16 +461,14 @@ services:
       - vault-worker
 
   rulesengine:
-    image: emqx/kuiper:0.3.2
+    image: emqx/kuiper:0.4.2
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"
     container_name: edgex-kuiper
     hostname: edgex-kuiper
     networks:
-      edgex-network:
-        aliases:
-          - edgex-kuiper
+      - edgex-network
     environment:
       # KUIPER_DEBUG: "true"
       KUIPER_CONSOLE_LOG: "true"
@@ -502,15 +485,13 @@ services:
   # If still required, simply uncomment the block below and comment out the block above.
   #
   # rulesengine:
-  #   image: edgexfoundry/docker-support-rulesengine:1.2.0
+  #   image: edgexfoundry/docker-support-rulesengine:1.2.1
   #   ports:
   #     - "127.0.0.1:48075:48075"
   #   container_name: edgex-support-rulesengine
   #   hostname: edgex-support-rulesengine
   #   networks:
-  #     edgex-network:
-  #       aliases:
-  #         - edgex-support-rulesengine
+  #     - edgex-network
   #   depends_on:
   #     - app-service-rules
 
@@ -519,18 +500,17 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go:1.2.0
+    image: edgexfoundry/docker-device-virtual-go:1.2.1
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual
     hostname: edgex-device-virtual
     networks:
-      edgex-network:
-        aliases:
-        - edgex-device-virtual
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
+      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -538,90 +518,85 @@ services:
       - metadata
 
   device-rest:
-    image: edgexfoundry/docker-device-rest-go:1.1.0
+    image: edgexfoundry/docker-device-rest-go:1.1.1
     ports:
       - "127.0.0.1:49986:49986"
     container_name: edgex-device-rest
     hostname: edgex-device-rest
     networks:
-      edgex-network:
-        aliases:
-          - edgex-device-rest
+      - edgex-network
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
+      Service_Timeout: "20000"
     depends_on:
       - data
       - command
   #      - logging  # uncomment if re-enabled remote logging
 
-  # device-random:
-  #   image: edgexfoundry/docker-device-random-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49988:49988"
-  #   container_name: edgex-device-random
-  #   hostname: edgex-device-random
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-random
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-random
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-mqtt:
-  #   image: edgexfoundry/docker-device-mqtt-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49982:49982"
-  #   container_name: edgex-device-mqtt
-  #   hostname: edgex-device-mqtt
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-mqtt
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-mqtt
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-modbus:
-  #   image: edgexfoundry/docker-device-modbus-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49991:49991"
-  #   container_name: edgex-device-modbus
-  #   hostname: edgex-device-modbus
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-modbus
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-modbus
-  #   depends_on:
-  #     - data
-  #     - command
-  #
-  # device-snmp:
-  #   image: edgexfoundry/docker-device-snmp-go:1.2.0
-  #   ports:
-  #     - "127.0.0.1:49993:49993"
-  #   container_name: edgex-device-snmp
-  #   hostname: edgex-device-snmp
-  #   networks:
-  #     - edgex-network
-  #      aliases:
-  #      - edgex-device-snmp
-  #   environment:
-  #     <<: *common-variables
-  #     Service_Host: edgex-device-snmp
-  #   depends_on:
-  #     - data
-  #     - command
+#  device-random:
+#    image: edgexfoundry/docker-device-random-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49988:49988"
+#    container_name: edgex-device-random
+#    hostname: edgex-device-random
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-random
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-mqtt:
+#    image: edgexfoundry/docker-device-mqtt-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49982:49982"
+#    container_name: edgex-device-mqtt
+#    hostname: edgex-device-mqtt
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-mqtt
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-modbus:
+#    image: edgexfoundry/docker-device-modbus-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49991:49991"
+#    container_name: edgex-device-modbus
+#    hostname: edgex-device-modbus
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-modbus
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
+#
+#  device-snmp:
+#    image: edgexfoundry/docker-device-snmp-go:1.2.1
+#    ports:
+#      - "127.0.0.1:49993:49993"
+#    container_name: edgex-device-snmp
+#    hostname: edgex-device-snmp
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      Service_Host: edgex-device-snmp
+#      Service_Timeout: "20000"
+#    depends_on:
+#      - data
+#      - command
 
 networks:
   edgex-network:

--- a/releases/geneva/compose-files/docker-compose-geneva-redis.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis.yml
@@ -511,7 +511,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-virtual
-      Service_Timeout: "20000"
     depends_on:
       - consul
 #      - logging  # uncomment if re-enabled remote logging
@@ -529,7 +528,6 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-device-rest
-      Service_Timeout: "20000"
     depends_on:
       - data
       - command
@@ -546,7 +544,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-random
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -562,7 +559,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-mqtt
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -578,7 +574,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-modbus
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command
@@ -594,7 +589,6 @@ services:
 #    environment:
 #      <<: *common-variables
 #      Service_Host: edgex-device-snmp
-#      Service_Timeout: "20000"
 #    depends_on:
 #      - data
 #      - command

--- a/releases/geneva/compose-files/docker-compose-geneva-redis.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis.yml
@@ -358,6 +358,7 @@ services:
     environment:
       <<: *common-variables
       Service_Host: edgex-core-metadata
+      Service_Timeout: "20000"
       Notifications_Sender: edgex-core-metadata
       SecretStore_TokenFile: /tmp/edgex/secrets/edgex-core-metadata/secrets-token.json
     volumes:

--- a/releases/geneva/compose-files/docker-compose-geneva-redis.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis.yml
@@ -462,7 +462,7 @@ services:
       - vault-worker
 
   rulesengine:
-    image: emqx/kuiper:0.4.2
+    image: emqx/kuiper:0.4.2-alpine
     ports:
       - "127.0.0.1:48075:48075"
       - "127.0.0.1:20498:20498"

--- a/releases/geneva/compose-files/docker-compose-geneva-ui-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-ui-arm64.yml
@@ -18,12 +18,17 @@
 
 version: '3.4'
 
+networks:
+  compose-files_edgex-network:
+    external: true
+
 services:
   ui:
-    image: edgexfoundry/docker-edgex-ui-go-arm64:1.2.0
+    image: edgexfoundry/docker-edgex-ui-go-arm64:1.2.1
     ports:
       - "127.0.0.1:4000:4000"
     container_name: edgex-ui-go
     hostname: edgex-ui-go
-    network_mode: host
+    networks:
+      - compose-files_edgex-network
 

--- a/releases/geneva/compose-files/docker-compose-geneva-ui.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-ui.yml
@@ -18,12 +18,16 @@
 
 version: '3.4'
 
+networks:
+  compose-files_edgex-network:
+    external: true
+
 services:
   ui:
-    image: edgexfoundry/docker-edgex-ui-go:1.2.0
+    image: edgexfoundry/docker-edgex-ui-go:1.2.1
     ports:
       - "127.0.0.1:4000:4000"
     container_name: edgex-ui-go
     hostname: edgex-ui-go
-    network_mode: host
-
+    networks:
+      - compose-files_edgex-network


### PR DESCRIPTION
- Updated the versions of the services impacted by this dot release
- Cleaned up the `network` section so it is consistent across all the services
- Added missing override `Clients_Data_Host` for device services that have the Core Data client specified differently.
- Added UI back to the edgex network