### PR TITLE
fix: Geneva device-virtual-go v1.2.2 release updates

### DIFF
--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-arm64.yml
@@ -494,7 +494,7 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.1
+    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.2
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty-arm64.yml
@@ -278,7 +278,7 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.1
+    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.2
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo-no-secty.yml
@@ -278,7 +278,7 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go:1.2.1
+    image: edgexfoundry/docker-device-virtual-go:1.2.2
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual

--- a/releases/geneva/compose-files/docker-compose-geneva-mongo.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-mongo.yml
@@ -493,7 +493,7 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go:1.2.1
+    image: edgexfoundry/docker-device-virtual-go:1.2.2
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-arm64.yml
@@ -501,7 +501,7 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.1
+    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.2
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty-arm64.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty-arm64.yml
@@ -272,7 +272,7 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.1
+    image: edgexfoundry/docker-device-virtual-go-arm64:1.2.2
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual

--- a/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis-no-secty.yml
@@ -272,7 +272,7 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go:1.2.1
+    image: edgexfoundry/docker-device-virtual-go:1.2.2
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual

--- a/releases/geneva/compose-files/docker-compose-geneva-redis.yml
+++ b/releases/geneva/compose-files/docker-compose-geneva-redis.yml
@@ -501,7 +501,7 @@ services:
 #################################################################
 
   device-virtual:
-    image: edgexfoundry/docker-device-virtual-go:1.2.1
+    image: edgexfoundry/docker-device-virtual-go:1.2.2
     ports:
     - "127.0.0.1:49990:49990"
     container_name: edgex-device-virtual


### PR DESCRIPTION
Updated docker-compose files of Geneva to use v1.2.2 virtual device service

Signed-off-by: Felix Ting <felix@iotechsys.com>