### PR TITLE
feat: Add read-only flag to all services

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -52,6 +52,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48100:48100/tcp
+    read_only: true
   command:
     container_name: edgex-core-command
     depends_on:
@@ -82,6 +83,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48082:48082/tcp
+    read_only: true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
@@ -138,6 +140,7 @@ services:
     ports:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:48080:48080/tcp
+    read_only: true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
@@ -168,6 +171,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:6379:6379/tcp
+    read_only: true
     volumes:
     - db-data:/data:z
     - /tmp/edgex/secrets/edgex-redis:/tmp/edgex/secrets/edgex-redis:z
@@ -195,6 +199,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49986:49986/tcp
+    read_only: true
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
@@ -255,6 +260,7 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go-arm64:master
     networks:
       edgex-network: {}
+    read_only: true
     volumes:
     - consul-scripts:/consul/scripts:ro,z
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
@@ -289,10 +295,15 @@ services:
     - published: 8443
       target: 8443
     - 127.0.0.1:8444:8444/tcp
+    read_only: true
     restart: on-failure
+    tmpfs:
+    - /run
+    - /tmp
     tty: true
     volumes:
     - consul-scripts:/consul/scripts:ro,z
+    - kong:/usr/local/kong:rw
   kong-db:
     container_name: kong-db
     depends_on:
@@ -307,6 +318,11 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:5432:5432/tcp
+    read_only: true
+    tmpfs:
+    - /var/run
+    - /tmp
+    - /run
   kong-migrations:
     command: "/bin/sh -cx  'until /consul/scripts/consul-svc-healthy.sh kong-db;\n\
       \   do sleep 1;\ndone && kong migrations bootstrap; kong migrations list; code=$$?;\
@@ -323,6 +339,9 @@ services:
     image: kong:2.0.1-ubuntu
     networks:
       edgex-network: {}
+    read_only: true
+    tmpfs:
+    - /tmp
     volumes:
     - consul-scripts:/consul/scripts:ro,z
   metadata:
@@ -356,6 +375,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48081:48081/tcp
+    read_only: true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
@@ -388,6 +408,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48060:48060/tcp
+    read_only: true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
@@ -442,6 +463,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48085:48085/tcp
+    read_only: true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
@@ -452,6 +474,7 @@ services:
       REDIS5_PASSWORD_PATHNAME: /tmp/edgex/secrets/edgex-redis/redis5-password
     hostname: edgex-secrets-setup
     image: nexus3.edgexfoundry.org:10004/docker-edgex-secrets-setup-go-arm64:master
+    read_only: true
     tmpfs:
     - /tmp
     - /run
@@ -489,6 +512,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48090:48090/tcp
+    read_only: true
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock:z
   vault:
@@ -530,8 +554,10 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go-arm64:master
     networks:
       edgex-network: {}
+    read_only: true
     tmpfs:
     - /run
+    - /vault
     volumes:
     - consul-scripts:/consul/scripts:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
@@ -542,6 +568,7 @@ volumes:
   consul-data: {}
   consul-scripts: {}
   db-data: {}
+  kong: {}
   log-data: {}
   secrets-setup-cache: {}
   vault-config: {}

--- a/releases/nightly-build/compose-files/docker-compose-nexus-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-no-secty-arm64.yml
@@ -52,6 +52,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48100:48100/tcp
+    read_only: true
   command:
     container_name: edgex-core-command
     depends_on:
@@ -77,6 +78,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48082:48082/tcp
+    read_only: true
   consul:
     container_name: edgex-core-consul
     environment:
@@ -117,6 +119,7 @@ services:
     ports:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:48080:48080/tcp
+    read_only: true
   database:
     container_name: edgex-redis
     environment:
@@ -137,6 +140,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:6379:6379/tcp
+    read_only: true
     volumes:
     - db-data:/data:z
   device-rest:
@@ -163,6 +167,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49986:49986/tcp
+    read_only: true
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
@@ -214,6 +219,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48081:48081/tcp
+    read_only: true
   notifications:
     container_name: edgex-support-notifications
     depends_on:
@@ -238,6 +244,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48060:48060/tcp
+    read_only: true
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
@@ -284,6 +291,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48085:48085/tcp
+    read_only: true
   system:
     container_name: edgex-sys-mgmt-agent
     depends_on:
@@ -314,6 +322,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48090:48090/tcp
+    read_only: true
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock:z
 version: '3.7'

--- a/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
@@ -52,6 +52,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48100:48100/tcp
+    read_only: true
   command:
     container_name: edgex-core-command
     depends_on:
@@ -77,6 +78,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48082:48082/tcp
+    read_only: true
   consul:
     container_name: edgex-core-consul
     environment:
@@ -117,6 +119,7 @@ services:
     ports:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:48080:48080/tcp
+    read_only: true
   database:
     container_name: edgex-redis
     environment:
@@ -137,6 +140,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:6379:6379/tcp
+    read_only: true
     volumes:
     - db-data:/data:z
   device-rest:
@@ -163,6 +167,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49986:49986/tcp
+    read_only: true
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
@@ -214,6 +219,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48081:48081/tcp
+    read_only: true
   notifications:
     container_name: edgex-support-notifications
     depends_on:
@@ -238,6 +244,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48060:48060/tcp
+    read_only: true
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
@@ -284,6 +291,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48085:48085/tcp
+    read_only: true
   system:
     container_name: edgex-sys-mgmt-agent
     depends_on:
@@ -314,6 +322,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48090:48090/tcp
+    read_only: true
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock:z
 version: '3.7'

--- a/releases/nightly-build/compose-files/docker-compose-nexus-ui-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-ui-arm64.yml
@@ -33,5 +33,6 @@ services:
       edgex-network: null
     ports:
     - 127.0.0.1:4000:4000/tcp
+    read_only: true
 version: '3.7'
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus-ui.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-ui.yml
@@ -33,5 +33,6 @@ services:
       edgex-network: null
     ports:
     - 127.0.0.1:4000:4000/tcp
+    read_only: true
 version: '3.7'
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -52,6 +52,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48100:48100/tcp
+    read_only: true
   command:
     container_name: edgex-core-command
     depends_on:
@@ -82,6 +83,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48082:48082/tcp
+    read_only: true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
@@ -138,6 +140,7 @@ services:
     ports:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:48080:48080/tcp
+    read_only: true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
@@ -168,6 +171,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:6379:6379/tcp
+    read_only: true
     volumes:
     - db-data:/data:z
     - /tmp/edgex/secrets/edgex-redis:/tmp/edgex/secrets/edgex-redis:z
@@ -195,6 +199,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49986:49986/tcp
+    read_only: true
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
@@ -255,6 +260,7 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:master
     networks:
       edgex-network: {}
+    read_only: true
     volumes:
     - consul-scripts:/consul/scripts:ro,z
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
@@ -289,10 +295,15 @@ services:
     - published: 8443
       target: 8443
     - 127.0.0.1:8444:8444/tcp
+    read_only: true
     restart: on-failure
+    tmpfs:
+    - /run
+    - /tmp
     tty: true
     volumes:
     - consul-scripts:/consul/scripts:ro,z
+    - kong:/usr/local/kong:rw
   kong-db:
     container_name: kong-db
     depends_on:
@@ -307,6 +318,11 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:5432:5432/tcp
+    read_only: true
+    tmpfs:
+    - /var/run
+    - /tmp
+    - /run
   kong-migrations:
     command: "/bin/sh -cx  'until /consul/scripts/consul-svc-healthy.sh kong-db;\n\
       \   do sleep 1;\ndone && kong migrations bootstrap; kong migrations list; code=$$?;\
@@ -323,6 +339,9 @@ services:
     image: kong:2.0.1
     networks:
       edgex-network: {}
+    read_only: true
+    tmpfs:
+    - /tmp
     volumes:
     - consul-scripts:/consul/scripts:ro,z
   metadata:
@@ -356,6 +375,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48081:48081/tcp
+    read_only: true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
@@ -388,6 +408,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48060:48060/tcp
+    read_only: true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
@@ -442,6 +463,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48085:48085/tcp
+    read_only: true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
@@ -452,6 +474,7 @@ services:
       REDIS5_PASSWORD_PATHNAME: /tmp/edgex/secrets/edgex-redis/redis5-password
     hostname: edgex-secrets-setup
     image: nexus3.edgexfoundry.org:10004/docker-edgex-secrets-setup-go:master
+    read_only: true
     tmpfs:
     - /tmp
     - /run
@@ -489,6 +512,7 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:48090:48090/tcp
+    read_only: true
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock:z
   vault:
@@ -530,8 +554,10 @@ services:
     image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:master
     networks:
       edgex-network: {}
+    read_only: true
     tmpfs:
     - /run
+    - /vault
     volumes:
     - consul-scripts:/consul/scripts:ro,z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
@@ -542,6 +568,7 @@ volumes:
   consul-data: {}
   consul-scripts: {}
   db-data: {}
+  kong: {}
   log-data: {}
   secrets-setup-cache: {}
   vault-config: {}

--- a/releases/nightly-build/compose-files/source/docker-compose-nexus-add-device-services.yml
+++ b/releases/nightly-build/compose-files/source/docker-compose-nexus-add-device-services.yml
@@ -45,6 +45,7 @@ services:
       - "127.0.0.1:49986:49986"
     container_name: edgex-device-rest
     hostname: edgex-device-rest
+    read_only: true
     networks:
       - edgex-network
     env_file:

--- a/releases/nightly-build/compose-files/source/docker-compose-nexus-add-mqtt.yml
+++ b/releases/nightly-build/compose-files/source/docker-compose-nexus-add-mqtt.yml
@@ -25,6 +25,7 @@ services:
       - "127.0.0.1:1883:1883"
     container_name: edgex-mqtt-broker
     hostname: edgex-mqtt-broker
+    read_only: true
     networks:
       - edgex-network
     depends_on:
@@ -43,6 +44,7 @@ services:
       - "127.0.0.1:49982:49982"
     container_name: edgex-device-mqtt
     hostname: edgex-device-mqtt
+    read_only: true
     networks:
       - edgex-network
     env_file:

--- a/releases/nightly-build/compose-files/source/docker-compose-nexus-add-security.yml
+++ b/releases/nightly-build/compose-files/source/docker-compose-nexus-add-security.yml
@@ -24,6 +24,7 @@ volumes:
   vault-config:
   vault-file:
   vault-logs:
+  kong:
   # non-shared volumes
   secrets-setup-cache:
 
@@ -73,6 +74,7 @@ services:
     hostname: edgex-secrets-setup
     env_file:
       - database-security.env
+    read_only: true
     tmpfs:
       - /tmp
       - /run
@@ -90,10 +92,12 @@ services:
       - database-security.env
     environment:
       SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
+    read_only: true
     networks:
       - edgex-network
     tmpfs:
       - /run
+      - /vault
     volumes:
       - vault-config:/vault/config:z
       - consul-scripts:/consul/scripts:ro,z
@@ -108,10 +112,15 @@ services:
     image: postgres:${POSTGRES_VERSION}
     container_name: kong-db
     hostname: kong-db
+    read_only: true
     networks:
       - edgex-network
     ports:
         - "127.0.0.1:5432:5432"
+    tmpfs:
+      - /var/run
+      - /tmp
+      - /run
     environment:
       POSTGRES_DB: kong
       POSTGRES_USER: kong
@@ -122,6 +131,7 @@ services:
   kong-migrations:
     image: kong:${KONG_VERSION}${KONG_UBUNTU}
     container_name: kong-migrations
+    read_only: true
     networks:
       - edgex-network
     environment:
@@ -138,6 +148,8 @@ services:
       if [ $$code -eq 5 ]; then
         kong migrations up && kong migrations finish;
       fi'
+    tmpfs:
+      - /tmp
     volumes:
       - consul-scripts:/consul/scripts:ro,z
     depends_on:
@@ -148,6 +160,7 @@ services:
     image: kong:${KONG_VERSION}${KONG_UBUNTU}
     container_name: kong
     hostname: kong
+    read_only: true
     networks:
       - edgex-network
     ports:
@@ -166,11 +179,15 @@ services:
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_ADMIN_LISTEN: "0.0.0.0:8001, 0.0.0.0:8444 ssl"
     restart: on-failure
+    tmpfs:
+      - /run
+      - /tmp
     command: >
       /bin/sh -c 
       "until /consul/scripts/consul-svc-healthy.sh kong-migrations; do sleep 1; done;
       /docker-entrypoint.sh kong docker-start"
     volumes:
+      - kong:/usr/local/kong
       - consul-scripts:/consul/scripts:ro,z
     depends_on:
       - consul
@@ -186,6 +203,7 @@ services:
       "until /consul/scripts/consul-svc-healthy.sh kong; do sleep 1; done;
       until /consul/scripts/consul-svc-healthy.sh security-secretstore-setup; do sleep 1; done;
       /edgex/security-proxy-setup --init=true"
+    read_only: true
     networks:
       - edgex-network
     env_file:

--- a/releases/nightly-build/compose-files/source/docker-compose-nexus-base.yml
+++ b/releases/nightly-build/compose-files/source/docker-compose-nexus-base.yml
@@ -56,6 +56,7 @@ services:
       - "127.0.0.1:6379:6379"
     container_name: edgex-redis
     hostname: edgex-redis
+    read_only: true
     networks:
       - edgex-network
     env_file:
@@ -69,6 +70,7 @@ services:
       - "127.0.0.1:48090:48090"
     container_name: edgex-sys-mgmt-agent
     hostname: edgex-sys-mgmt-agent
+    read_only: true
     networks:
       - edgex-network
     env_file:
@@ -93,6 +95,7 @@ services:
       - "127.0.0.1:48060:48060"
     container_name: edgex-support-notifications
     hostname: edgex-support-notifications
+    read_only: true
     networks:
       - edgex-network
     env_file:
@@ -109,6 +112,7 @@ services:
       - "127.0.0.1:48081:48081"
     container_name: edgex-core-metadata
     hostname: edgex-core-metadata
+    read_only: true
     networks:
       - edgex-network
     env_file:
@@ -128,6 +132,7 @@ services:
       - "127.0.0.1:5563:5563"
     container_name: edgex-core-data
     hostname: edgex-core-data
+    read_only: true
     networks:
       - edgex-network
     env_file:
@@ -145,6 +150,7 @@ services:
       - "127.0.0.1:48082:48082"
     container_name: edgex-core-command
     hostname: edgex-core-command
+    read_only: true
     networks:
       - edgex-network
     env_file:
@@ -162,6 +168,7 @@ services:
       - "127.0.0.1:48085:48085"
     container_name: edgex-support-scheduler
     hostname: edgex-support-scheduler
+    read_only: true
     networks:
       - edgex-network
     env_file:
@@ -180,6 +187,7 @@ services:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules
     hostname: edgex-app-service-configurable-rules
+    read_only: true
     networks:
       - edgex-network
     env_file:

--- a/releases/nightly-build/compose-files/source/docker-compose-nexus-ui.yml
+++ b/releases/nightly-build/compose-files/source/docker-compose-nexus-ui.yml
@@ -30,5 +30,6 @@ services:
       - "127.0.0.1:4000:4000"
     container_name: edgex-ui-go
     hostname: edgex-ui-go
+    read_only: true
     networks:
       - edgex-network


### PR DESCRIPTION
feat: Add read-only flag to all services
close #1921

Signed-off-by: Brian McGinn <brian.mcginn@intel.com>

The following containers require read/write permission to modify files within the container and do not support the read_only flag:
- device-virtual
- vault
- consul
- rulesengine

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
docker containers have read and write permissions
https://github.com/edgexfoundry/edgex-go/issues/1921

Issue Number: 1921


## What is the new behavior?
docker containers will be read only unless required to write.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?
no

## Other information