### PR TITLE
fix: Make /consul/scripts directory writable even in non-secure consul.

### DIFF
--- a/releases/nightly-build/compose-files/docker-compose-nexus-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-no-secty-arm64.yml
@@ -94,6 +94,7 @@ services:
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
+    - consul-scripts:/consul/scripts:z
   data:
     container_name: edgex-core-data
     depends_on:
@@ -330,6 +331,7 @@ version: '3.7'
 volumes:
   consul-config: {}
   consul-data: {}
+  consul-scripts: {}
   db-data: {}
   log-data: {}
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
@@ -94,6 +94,7 @@ services:
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
+    - consul-scripts:/consul/scripts:z
   data:
     container_name: edgex-core-data
     depends_on:
@@ -330,6 +331,7 @@ version: '3.7'
 volumes:
   consul-config: {}
   consul-data: {}
+  consul-scripts: {}
   db-data: {}
   log-data: {}
 

--- a/releases/nightly-build/compose-files/source/docker-compose-nexus-add-security.yml
+++ b/releases/nightly-build/compose-files/source/docker-compose-nexus-add-security.yml
@@ -19,7 +19,6 @@
 version: '3.7'
 
 volumes:
-  consul-scripts:
   vault-init:
   vault-config:
   vault-file:
@@ -34,7 +33,6 @@ services:
       SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
       EDGEX_SECURE: "true"
     volumes:
-      - consul-scripts:/consul/scripts:z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z

--- a/releases/nightly-build/compose-files/source/docker-compose-nexus-base.yml
+++ b/releases/nightly-build/compose-files/source/docker-compose-nexus-base.yml
@@ -33,6 +33,7 @@ volumes:
   log-data:
   consul-config:
   consul-data:
+  consul-scripts:
 
 services:
   consul:
@@ -47,6 +48,7 @@ services:
     volumes:
       - consul-config:/consul/config:z
       - consul-data:/consul/data:z
+      - consul-scripts:/consul/scripts:z
     environment: 
       EDGEX_DB: redis
       EDGEX_SECURE: "false"


### PR DESCRIPTION
Consul health check scripts are copied into /consul/scripts directory
even if related health-checks needed for security are not enabled.
Make the consul-scripts volume available in all configurations,
to avoid failure of the entrypoint script.

Fixes #301

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>