### PR TITLE
ci: init Jenkins smoke test pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,29 @@
+pipeline {
+    agent {
+        label 'centos7-docker-4c-2g' 
+    }
+    options {
+        timestamps()
+        quietPeriod(5) // wait a few seconds before starting to aggregate builds...??
+        durabilityHint 'PERFORMANCE_OPTIMIZED'
+        timeout(360)
+    }
+    stages {
+        stage('Smoke Tests') {
+            when {
+                expression { !edgex.isReleaseStream() }
+            }
+            steps {
+                build job: '/edgexfoundry/edgex-taf-pipelines/smoke-test', parameters: [string(name: 'SHA1', value: env.GIT_COMMIT), string(name: 'TEST_ARCH', value: 'All'), string(name: 'WITH_SECURITY', value: 'All')]
+            }
+        }
+    }
+    post {
+        always {
+            edgeXInfraPublish()
+        }
+        cleanup {
+            cleanWs()
+        }
+    }
+}


### PR DESCRIPTION
Initialize pipeline to run edgex-taf smoke tests.

**Note:** Smoke tests take about 30-35 minutes to run.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
N/A

## Other information