### PR TITLE
feat(security): Remove Vault dependency on Consul

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -64,7 +64,6 @@ services:
       - vault-init:/vault/init:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
     depends_on:
-      - consul
       - security-secrets-setup
 
   security-secrets-setup:

--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -541,7 +541,6 @@ services:
     - IPC_LOCK
     container_name: edgex-vault
     depends_on:
-    - consul
     - security-secrets-setup
     entrypoint:
     - /vault/init/start_vault.sh

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -541,7 +541,6 @@ services:
     - IPC_LOCK
     container_name: edgex-vault
     depends_on:
-    - consul
     - security-secrets-setup
     entrypoint:
     - /vault/init/start_vault.sh


### PR DESCRIPTION
With the Vault's backend storage been changed to filesystem instead of Consul,  will no longer depend on  in the compose file.

This together with edgex-go's change and edgex-consul's vault healthy check removal shall close the issue edgexfoundry/edgex-go#2882 .

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Vault depends on Consul

## Issue Number:  
Fixes edgexfoundry/edgex-go#2882


## What is the new behavior?
Vault will not depend on Consul directly

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?

**Note:  For this compose up working correctly, it requires the following two PRs merged into master first:**
1. https://github.com/edgexfoundry/edgex-go/pull/2886 
1. https://github.com/edgexfoundry/docker-edgex-consul/pull/40

## Other information
If tested locally, do the following steps:
1. Clone the code from https://github.com/edgexfoundry/edgex-go/pull/2886  
1. Build the latest docker images for `edgex-go`: `make docker`
1. Clone the code from https://github.com/edgexfoundry/docker-edgex-consul/pull/40 
1. Build the latest `edgex-core-consul` docker image: `make docker`
1. Go to `compose-builder` sub-directory and do `make gen dev` to generate the local version of `docker-compose.yml` to run
1. Modify the `edgex-core-consul` docker image in the generated docker-compose file to point to the local built docker image above: 
   ```yaml
   image: edgexfoundry/docker-edgex-consul:0.0.0
   ```
1. In the command-line, run `docker-compose up` and all services should started up ok (can be checked and see using `docker ps` and individual docker logs via portainer).   Also it should be ok in the docker logs `edgex-core-consul`


