### PR TITLE
feat: Persistent Streams & Rules with RO Container

### DIFF
--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -34,6 +34,7 @@ volumes:
   consul-config:
   consul-data:
   consul-scripts:
+  kuiper-data:
 
 services:
   consul:
@@ -212,8 +213,11 @@ services:
       - "127.0.0.1:20498:20498"
     container_name: edgex-kuiper
     hostname: edgex-kuiper
+    read_only: true
     networks:
       - edgex-network
+    volumes:
+      - kuiper-data:/kuiper/data:z
     environment:
       # KUIPER_DEBUG: "true"
       KUIPER__BASIC__CONSOLELOG: "true"

--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -433,6 +433,9 @@ services:
     ports:
     - 127.0.0.1:20498:20498/tcp
     - 127.0.0.1:48075:48075/tcp
+    read_only: true
+    volumes:
+    - kuiper-data:/kuiper/data:z
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
@@ -601,6 +604,7 @@ volumes:
   consul-scripts: {}
   db-data: {}
   kong: {}
+  kuiper-data: {}
   log-data: {}
   postgres-data: {}
   secrets-setup-cache: {}

--- a/releases/nightly-build/compose-files/docker-compose-nexus-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-no-secty-arm64.yml
@@ -271,6 +271,9 @@ services:
     ports:
     - 127.0.0.1:20498:20498/tcp
     - 127.0.0.1:48075:48075/tcp
+    read_only: true
+    volumes:
+    - kuiper-data:/kuiper/data:z
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
@@ -337,5 +340,6 @@ volumes:
   consul-data: {}
   consul-scripts: {}
   db-data: {}
+  kuiper-data: {}
   log-data: {}
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
@@ -271,6 +271,9 @@ services:
     ports:
     - 127.0.0.1:20498:20498/tcp
     - 127.0.0.1:48075:48075/tcp
+    read_only: true
+    volumes:
+    - kuiper-data:/kuiper/data:z
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
@@ -337,5 +340,6 @@ volumes:
   consul-data: {}
   consul-scripts: {}
   db-data: {}
+  kuiper-data: {}
   log-data: {}
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -433,6 +433,9 @@ services:
     ports:
     - 127.0.0.1:20498:20498/tcp
     - 127.0.0.1:48075:48075/tcp
+    read_only: true
+    volumes:
+    - kuiper-data:/kuiper/data:z
   scheduler:
     container_name: edgex-support-scheduler
     depends_on:
@@ -601,6 +604,7 @@ volumes:
   consul-scripts: {}
   db-data: {}
   kong: {}
+  kuiper-data: {}
   log-data: {}
   postgres-data: {}
   secrets-setup-cache: {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
Data does not persist and container was not read-only


## Issue Number:
#320 

## What is the new behavior?
Added the ability to persist streams/rules data when the kuiper container is
recreated. Also made the container read-only.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information