### PR TITLE
feat: Use secrets-config to generate API Gateway token

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -130,17 +130,7 @@ gen:
 	docker-compose -p edgex $(COMPOSE_FILES) config > docker-compose.yml
 
 get-token:
-	docker run --rm \
-		-e SECRETSERVICE_SERVER=edgex-vault \
-		-e KONGURL_SERVER=kong \
-		-e SECRETSERVICE_TOKENPATH=/tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json \
-		-e SECRETSERVICE_CACERTPATH=/tmp/edgex/secrets/ca/ca.pem \
-		--network edgex_edgex-network \
-		--volume /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z \
-		--volume /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z \
-		$(CORE_EDGEX_REPOSITORY)/docker-edgex-security-proxy-setup-go$(ARCH):$(CORE_EDGEX_VERSION)$(DEV) \
-		--init=false --useradd=developer --group=admin \
-		| grep " access token for user developer" | sed 's/.*: \([^.]*\.[^.]*\.[^.]*\).*/\1/'
+	bash -c ./get-api-gateway-token.sh
 
 ui-down:
 	DEV= \

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -132,7 +132,7 @@ gen:
 get-token:
 	DEV=$(DEV) \
 	ARCH=$(ARCH) \
-	bash -c ./get-api-gateway-token.sh
+	sh -c ./get-api-gateway-token.sh
 
 ui-down:
 	DEV= \

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -130,6 +130,8 @@ gen:
 	docker-compose -p edgex $(COMPOSE_FILES) config > docker-compose.yml
 
 get-token:
+	DEV=$(DEV) \
+	ARCH=$(ARCH) \
 	bash -c ./get-api-gateway-token.sh
 
 ui-down:

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -132,7 +132,7 @@ gen:
 get-token:
 	DEV=$(DEV) \
 	ARCH=$(ARCH) \
-	sh -c ./get-api-gateway-token.sh
+	sh ./get-api-gateway-token.sh
 
 ui-down:
 	DEV= \

--- a/compose-builder/get-api-gateway-token.sh
+++ b/compose-builder/get-api-gateway-token.sh
@@ -10,7 +10,7 @@ if [ "$DEV" = "-dev" ]; then
   CORE_EDGEX_VERSION=0.0.0
 fi
 
-
+rm -rf keys
 mkdir keys
 openssl genpkey -algorithm RSA -out keys/rsa4096.key -pkeyopt rsa_keygen_bits:4096
 openssl rsa -in keys/rsa4096.key -pubout -out keys/rsa4096.pub

--- a/compose-builder/get-api-gateway-token.sh
+++ b/compose-builder/get-api-gateway-token.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+mkdir keys
+openssl genpkey -algorithm RSA -out keys/rsa4096.key -pkeyopt rsa_keygen_bits:4096
+openssl rsa -in keys/rsa4096.key -pubout -out keys/rsa4096.pub
+JWT=`docker run --rm -it -e KONGURL_SERVER=kong --network edgex_edgex-network --entrypoint "" \
+       -v ${PWD}/keys:/keys nexus3.edgexfoundry.org:10004/docker-security-proxy-setup-go:master \
+        /edgex/secrets-config proxy adduser --token-type jwt --algorithm RS256 --public_key /keys/rsa4096.pub --user testinguser`
+docker run --rm -it -e KONGURL_SERVER=kong --network edgex_edgex-network --entrypoint "" \
+       -v ${PWD}/keys:/keys nexus3.edgexfoundry.org:10004/docker-security-proxy-setup-go:master \
+       /edgex/secrets-config proxy jwt --algorithm RS256 --id ${JWT} --private_key /keys/rsa4096.key
+rm -rf keys
+

--- a/compose-builder/get-api-gateway-token.sh
+++ b/compose-builder/get-api-gateway-token.sh
@@ -1,13 +1,24 @@
 #!/bin/sh
 
+# DEV and ARCH are set in environment prior to calling script
+# example: DEV=-dev ARCH=-arm64 ./get-api-gateway-token.sh
+
+# versions are loaded from .env file
+. ./.env
+
+if [ "$DEV" = "-dev" ]; then
+  CORE_EDGEX_VERSION=0.0.0
+fi
+
+
 mkdir keys
 openssl genpkey -algorithm RSA -out keys/rsa4096.key -pkeyopt rsa_keygen_bits:4096
 openssl rsa -in keys/rsa4096.key -pubout -out keys/rsa4096.pub
-JWT=`docker run --rm -it -e KONGURL_SERVER=kong --network edgex_edgex-network --entrypoint "" \
-       -v ${PWD}/keys:/keys nexus3.edgexfoundry.org:10004/docker-security-proxy-setup-go:master \
+JWT=`docker run --rm -it -e KONGURL_SERVER=kong --network edgex_edgex-network --entrypoint "" -v ${PWD}/keys:/keys \
+       ${CORE_EDGEX_REPOSITORY}/docker-security-proxy-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV} \
         /edgex/secrets-config proxy adduser --token-type jwt --algorithm RS256 --public_key /keys/rsa4096.pub --user testinguser`
-docker run --rm -it -e KONGURL_SERVER=kong --network edgex_edgex-network --entrypoint "" \
-       -v ${PWD}/keys:/keys nexus3.edgexfoundry.org:10004/docker-security-proxy-setup-go:master \
+docker run --rm -it -e KONGURL_SERVER=kong --network edgex_edgex-network --entrypoint "" -v ${PWD}/keys:/keys \
+       ${CORE_EDGEX_REPOSITORY}/docker-security-proxy-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV} \
        /edgex/secrets-config proxy jwt --algorithm RS256 --id ${JWT} --private_key /keys/rsa4096.key
 rm -rf keys
 

--- a/compose-builder/get-api-gateway-token.sh
+++ b/compose-builder/get-api-gateway-token.sh
@@ -12,13 +12,14 @@ fi
 
 rm -rf keys
 mkdir keys
-openssl genpkey -algorithm RSA -out keys/rsa4096.key -pkeyopt rsa_keygen_bits:4096
-openssl rsa -in keys/rsa4096.key -pubout -out keys/rsa4096.pub
-JWT=`docker run --rm -it -e KONGURL_SERVER=kong --network edgex_edgex-network --entrypoint "" -v ${PWD}/keys:/keys \
-       ${CORE_EDGEX_REPOSITORY}/docker-security-proxy-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV} \
-        /edgex/secrets-config proxy adduser --token-type jwt --algorithm RS256 --public_key /keys/rsa4096.pub --user testinguser`
+openssl genpkey -algorithm RSA -out keys/rsa4096.key -pkeyopt rsa_keygen_bits:4096 2> /dev/null
+openssl rsa -in keys/rsa4096.key -pubout -out keys/rsa4096.pub 2> /dev/null
+ID=`uuidgen`
 docker run --rm -it -e KONGURL_SERVER=kong --network edgex_edgex-network --entrypoint "" -v ${PWD}/keys:/keys \
        ${CORE_EDGEX_REPOSITORY}/docker-security-proxy-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV} \
-       /edgex/secrets-config proxy jwt --algorithm RS256 --id ${JWT} --private_key /keys/rsa4096.key
+        /edgex/secrets-config proxy adduser --token-type jwt --id ${ID} --algorithm RS256 --public_key /keys/rsa4096.pub --user testinguser > /dev/null
+docker run --rm -it -e KONGURL_SERVER=kong --network edgex_edgex-network --entrypoint "" -v ${PWD}/keys:/keys \
+       ${CORE_EDGEX_REPOSITORY}/docker-security-proxy-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV} \
+       /edgex/secrets-config proxy jwt --algorithm RS256 --id ${ID} --private_key /keys/rsa4096.key
 rm -rf keys
 

--- a/compose-builder/get-api-gateway-token.sh
+++ b/compose-builder/get-api-gateway-token.sh
@@ -12,13 +12,14 @@ fi
 
 rm -rf keys
 mkdir keys
-openssl genpkey -algorithm RSA -out keys/rsa4096.key -pkeyopt rsa_keygen_bits:4096 2> /dev/null
-openssl rsa -in keys/rsa4096.key -pubout -out keys/rsa4096.pub 2> /dev/null
+openssl ecparam -name prime256v1 -genkey -noout -out keys/ec256.key 2> /dev/null
+cat keys/ec256.key | openssl ec -out keys/ec256.pub 2> /dev/null
+
 ID=`uuidgen`
 docker run --rm -it -e KONGURL_SERVER=kong --network edgex_edgex-network --entrypoint "" -v ${PWD}/keys:/keys \
        ${CORE_EDGEX_REPOSITORY}/docker-security-proxy-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV} \
-        /edgex/secrets-config proxy adduser --token-type jwt --id ${ID} --algorithm RS256 --public_key /keys/rsa4096.pub --user testinguser > /dev/null
+        /edgex/secrets-config proxy adduser --token-type jwt --id ${ID} --algorithm ES256  --public_key /keys/ec256.pub --user testinguser > /dev/null
 docker run --rm -it -e KONGURL_SERVER=kong --network edgex_edgex-network --entrypoint "" -v ${PWD}/keys:/keys \
        ${CORE_EDGEX_REPOSITORY}/docker-security-proxy-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV} \
-       /edgex/secrets-config proxy jwt --algorithm RS256 --id ${ID} --private_key /keys/rsa4096.key
+       /edgex/secrets-config proxy jwt --algorithm ES256 --id ${ID} --private_key /keys/ec256.key
 rm -rf keys


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?

Get token uses deprecated proxy-setup addUser command to generate API Gateway token

## Issue Number: #361


## What is the new behavior?

Get token now uses new secrets-config proxy addUser & jwt commands to generate API Gateway token.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information