### PR TITLE
feat(security): Add upload-tls-cert makefile target

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -13,8 +13,8 @@
 #  *
 #  *******************************************************************************/
 
-.PHONY: help portainer portainer-down build build-ui run pull gen get-token ui-down down clean
-.SILENT: help get-token del-token
+.PHONY: help portainer portainer-down build build-ui run pull gen get-token upload-tls-cert ui-down down clean
+.SILENT: help get-token del-token upload-tls-cert
 
 include .env
 
@@ -133,6 +133,11 @@ get-token:
 	DEV=$(DEV) \
 	ARCH=$(ARCH) \
 	sh ./get-api-gateway-token.sh
+
+upload-tls-cert:
+	DEV=$(DEV) \
+	ARCH=$(ARCH) \
+	sh ./upload-api-gateway-cert.sh
 
 ui-down:
 	DEV= \

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -187,6 +187,20 @@ Options:
     dev:    Generates a Kong access token using local dev built docker image
             'make docker', which creates docker images tagged with '0.0.0-dev'    
 ```
+
+```
+upload-tls-cert [options] <environment_variables>
+Upload a bring-your-own (BYO) TLS certificate to the Kong proxy server as specified by:
+Options:
+    arm64:  Upload TLS certificate to the Kong server using ARM64 image
+    dev:    Upload TLS certificate to the Kong server using local dev built docker image
+            'make docker', which creates docker images tagged with '0.0.0-dev'
+Environment Variables: 
+    CERT_INPUT_FILE=<full_path_to_cert_file>: the full file name path to your own certificate file, this is required
+    KEY_INPUT_FILE=<full_path_to_key_file>: the full file name path to your own key file, this is required
+    EXTRA_SNIS="comma_separated_server_name_list_if_any": an extra server name indicator list in addition to localhost and kong, this is optional and can be omitted
+```
+
 ```
 ui-down 
 Stops the optional EdgeX UI service

--- a/compose-builder/get-api-gateway-token.sh
+++ b/compose-builder/get-api-gateway-token.sh
@@ -7,6 +7,7 @@
 . ./.env
 
 if [ "$DEV" = "-dev" ]; then
+  CORE_EDGEX_REPOSITORY=edgexfoundry
   CORE_EDGEX_VERSION=0.0.0
 fi
 

--- a/compose-builder/upload-api-gateway-cert.sh
+++ b/compose-builder/upload-api-gateway-cert.sh
@@ -3,7 +3,7 @@
 # usage function for uploading tls cert:
 usage()
 {
-  echo "Usage: make upload-tls-cert CERT_INPUT_FILE=<full-path-for-cert-input-file> KEY_INPUT_FILE=<full-path-for-key-input-file> [EXTRA-SNIS=<comma-separated-list-for-server-name>]"
+  echo "Usage: uplaod-api-gateway-cert.sh CERT_INPUT_FILE=<full-path-for-cert-input-file> KEY_INPUT_FILE=<full-path-for-key-input-file> [EXTRA-SNIS=<comma-separated-list-for-server-name>]"
   echo "\tBoth CERT_INPUT_FILE and KEY_INPUT_FILE are required."
   echo "\tEXTRA_SNIS is optional"
   exit 1

--- a/compose-builder/upload-api-gateway-cert.sh
+++ b/compose-builder/upload-api-gateway-cert.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+# usage function for uploading tls cert:
+usage()
+{
+  echo "Usage: make upload-tls-cert CERT_INPUT_FILE=<full-path-for-cert-input-file> KEY_INPUT_FILE=<full-path-for-key-input-file> [EXTRA-SNIS=<comma-separated-list-for-server-name>]"
+  echo "\tBoth CERT_INPUT_FILE and KEY_INPUT_FILE are required."
+  echo "\tEXTRA_SNIS is optional"
+  exit 1
+}
+
+# DEV and ARCH are set in environment prior to calling script
+# example: DEV=-dev ARCH=-arm64 ./upload-api-gateway-cert.sh
+
+# versions are loaded from .env file
+. ./.env
+
+if [ "$DEV" = "-dev" ]; then
+  CORE_EDGEX_REPOSITORY=edgexfoundry
+  CORE_EDGEX_VERSION=0.0.0
+fi
+
+# required input sanity checks
+if [ "$CERT_INPUT_FILE" = "" ]; then
+  echo "Missing env parameter: CERT_INPUT_FILE"
+  usage
+fi
+if [ "$KEY_INPUT_FILE" = "" ]; then
+  echo "Missing  env parameter: KEY_INPUT_FILE"
+  usage
+fi
+
+# staging the input files into temporary files
+STAGING="staging-cert"
+rm -rf ${STAGING}
+mkdir -p ${STAGING}
+
+cp ${CERT_INPUT_FILE} ${STAGING}
+cp ${KEY_INPUT_FILE} ${STAGING}
+
+CERT_FILE_NAME=$(basename ${CERT_INPUT_FILE})
+KEY_FILE_NAME=$(basename ${KEY_INPUT_FILE})
+
+echo "Uploading Kong TLS certificate with certificate file: ${CERT_FILE_NAME}, key file: ${KEY_FILE_NAME}, extra server name list: [${EXTRA_SNIS}]"
+docker run --rm -it -e KONGURL_SERVER=kong --network edgex_edgex-network --entrypoint "" -v ${PWD}/${STAGING}:/${STAGING} \
+       ${CORE_EDGEX_REPOSITORY}/docker-security-proxy-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV} \
+        /edgex/secrets-config proxy tls --incert /${STAGING}/${CERT_FILE_NAME} \
+        --inkey /${STAGING}/${KEY_FILE_NAME} \
+        --snis "${EXTRA_SNIS}"
+
+if [ $? = 0 ]; then
+  echo "Kong TLS certificate uploaded"
+else
+  echo "Failed to upload Kong TLS certificate"
+fi
+
+rm -rf ${STAGING}


### PR DESCRIPTION
Add a new makefile target for compose-builder: upload-tls-cert
This can be used to setup a bring-your-own (BYO) TLS certificate for Kong proxy server in an Edgex docker-compose stack

Closes: edgexfoundry/edgex-go#1926, edgexfoundry/edgex-go#1922

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently, there is no make target to upload Kong's TLS certificate.

## Issue Number: edgexfoundry/edgex-go#1926


## What is the new behavior?
New make file target `upload-tls-cert` is added.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
To test this locally, do the following steps:
1. Go to `edgex-go`, and create the local version of docker images by `make docker`
1. In the `developer-scripts` repo, git clone this PR, and change the directory to `compose-builder`
1. Run the dev version of EdgeX stack via `make run dev`
1. Run the following make command: 
```sh
$  make upload-tls-cert dev CERT_INPUT_FILE=~/go/src/github.com/edgexfoundry/edgex-go/internal/security/config/command/proxy/tls/testdata/testCert.pem KEY_INPUT_FILE=~/go/src/github.com/edgexfoundry/edgex-go/internal/security/config/command/proxy/tls/testdata/testCert.prkey
```
5. You should see no error return, and see the message `Kong TLS certificate uploaded`.
