### PR TITLE
feat: Combine Kong Service Containers

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -146,35 +146,6 @@ services:
       POSTGRES_PASSWORD: ${KONG_POSTGRES_PASSWORD:-kong}
     depends_on:
       - security-secrets-setup
-
-  kong-migrations:
-    image: kong:${KONG_VERSION}${KONG_UBUNTU}
-    container_name: kong-migrations
-    read_only: true
-    networks:
-      - edgex-network
-    environment:
-      KONG_DATABASE: postgres
-      KONG_PG_HOST: kong-db
-      KONG_PG_PASSWORD: ${KONG_POSTGRES_PASSWORD:-kong}
-    command: >
-      /bin/sh -cx 
-      'until /consul/scripts/consul-svc-healthy.sh kong-db;
-         do sleep 1;
-      done && kong migrations bootstrap;
-      kong migrations list;
-      code=$$?;
-      if [ $$code -eq 5 ]; then
-        kong migrations up && kong migrations finish;
-      fi'
-    tmpfs:
-      - /tmp
-    volumes:
-      - consul-scripts:/consul/scripts:ro,z
-    depends_on:
-      - consul
-      - kong-db
-
   kong:
     image: kong:${KONG_VERSION}${KONG_UBUNTU}
     container_name: kong
@@ -202,16 +173,26 @@ services:
       - /run
       - /tmp
     command: >
-      /bin/sh -c 
-      "until /consul/scripts/consul-svc-healthy.sh kong-migrations; do sleep 1; done;
-      /docker-entrypoint.sh kong docker-start"
+      /bin/sh -cx "
+        until /consul/scripts/consul-svc-healthy.sh kong-db;
+          do sleep 1;
+        done;
+        kong migrations bootstrap;
+        kong migrations list;
+        code=$$?;
+        if [ $$code -eq 5 ]; then
+          kong migrations up && kong migrations finish;
+        fi;
+        until /consul/scripts/consul-svc-healthy.sh kong-migrations;
+          do sleep 1;
+        done;
+        /docker-entrypoint.sh kong docker-start"
     volumes:
       - kong:/usr/local/kong
       - consul-scripts:/consul/scripts:ro,z
     depends_on:
       - consul
       - kong-db
-      - kong-migrations
 
   edgex-proxy:
     image: ${CORE_EDGEX_REPOSITORY}/docker-security-proxy-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}

--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -259,15 +259,15 @@ services:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
   kong:
-    command: '/bin/sh -c  "until /consul/scripts/consul-svc-healthy.sh kong-migrations;
-      do sleep 1; done; /docker-entrypoint.sh kong docker-start"
-
-      '
+    command: "/bin/sh -cx \"\n  until /consul/scripts/consul-svc-healthy.sh kong-db;\n\
+      \    do sleep 1;\n  done;\n  kong migrations bootstrap;\n  kong migrations list;\n\
+      \  code=$$?;\n  if [ $$code -eq 5 ]; then\n    kong migrations up && kong migrations\
+      \ finish;\n  fi;\n  until /consul/scripts/consul-svc-healthy.sh kong-migrations;\n\
+      \    do sleep 1;\n  done;\n  /docker-entrypoint.sh kong docker-start\"\n"
     container_name: kong
     depends_on:
     - consul
     - kong-db
-    - kong-migrations
     environment:
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
@@ -316,27 +316,6 @@ services:
     - /run
     volumes:
     - postgres-data:/var/lib/postgresql/data:z
-  kong-migrations:
-    command: "/bin/sh -cx  'until /consul/scripts/consul-svc-healthy.sh kong-db;\n\
-      \   do sleep 1;\ndone && kong migrations bootstrap; kong migrations list; code=$$?;\
-      \ if [ $$code -eq 5 ]; then\n  kong migrations up && kong migrations finish;\n\
-      fi'\n"
-    container_name: kong-migrations
-    depends_on:
-    - consul
-    - kong-db
-    environment:
-      KONG_DATABASE: postgres
-      KONG_PG_HOST: kong-db
-      KONG_PG_PASSWORD: kong
-    image: kong:2.0.5-ubuntu
-    networks:
-      edgex-network: {}
-    read_only: true
-    tmpfs:
-    - /tmp
-    volumes:
-    - consul-scripts:/consul/scripts:ro,z
   metadata:
     container_name: edgex-core-metadata
     depends_on:

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -259,15 +259,15 @@ services:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
   kong:
-    command: '/bin/sh -c  "until /consul/scripts/consul-svc-healthy.sh kong-migrations;
-      do sleep 1; done; /docker-entrypoint.sh kong docker-start"
-
-      '
+    command: "/bin/sh -cx \"\n  until /consul/scripts/consul-svc-healthy.sh kong-db;\n\
+      \    do sleep 1;\n  done;\n  kong migrations bootstrap;\n  kong migrations list;\n\
+      \  code=$$?;\n  if [ $$code -eq 5 ]; then\n    kong migrations up && kong migrations\
+      \ finish;\n  fi;\n  until /consul/scripts/consul-svc-healthy.sh kong-migrations;\n\
+      \    do sleep 1;\n  done;\n  /docker-entrypoint.sh kong docker-start\"\n"
     container_name: kong
     depends_on:
     - consul
     - kong-db
-    - kong-migrations
     environment:
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
@@ -316,27 +316,6 @@ services:
     - /run
     volumes:
     - postgres-data:/var/lib/postgresql/data:z
-  kong-migrations:
-    command: "/bin/sh -cx  'until /consul/scripts/consul-svc-healthy.sh kong-db;\n\
-      \   do sleep 1;\ndone && kong migrations bootstrap; kong migrations list; code=$$?;\
-      \ if [ $$code -eq 5 ]; then\n  kong migrations up && kong migrations finish;\n\
-      fi'\n"
-    container_name: kong-migrations
-    depends_on:
-    - consul
-    - kong-db
-    environment:
-      KONG_DATABASE: postgres
-      KONG_PG_HOST: kong-db
-      KONG_PG_PASSWORD: kong
-    image: kong:2.0.5
-    networks:
-      edgex-network: {}
-    read_only: true
-    tmpfs:
-    - /tmp
-    volumes:
-    - consul-scripts:/consul/scripts:ro,z
   metadata:
     container_name: edgex-core-metadata
     depends_on:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
Kong service definition splits migrations and persistent service into 2 separate services, leaving migrations a dead container after it completes execution.


## Issue Number:
#365 

## What is the new behavior?
Modified the main kong container to run the command issued from the kong migration container. Both containers derive from the same base and their service definitions are identical. Net result - 1 less container.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
n/a

## Other information