### PR TITLE
feat(security): Remove secrets-setup service from compose

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -26,7 +26,6 @@ volumes:
   kong:
   # non-shared volumes
   postgres-data:
-  secrets-setup-cache:
 
 services:
   consul:
@@ -34,12 +33,8 @@ services:
       SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
       EDGEX_SECURE: "true"
     volumes:
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
-      - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
       - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
-    depends_on:
-      - security-secrets-setup
 
   vault:
     image: vault:${VAULT_VERSION}
@@ -53,34 +48,27 @@ services:
       - "IPC_LOCK"
     tmpfs:
       - /vault/config
-    entrypoint: ["/vault/init/start_vault.sh"]
+    command: server
     environment:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
       VAULT_UI: "true"
+      # temporary add config here, will be absorbed into security-bootstrapper's installation once that is ready
+      VAULT_LOG_LEVEL: INFO
+      VAULT_LOCAL_CONFIG: >
+          listener "tcp" { 
+              tls_disable = "1" 
+              address = "edgex-vault:8200" 
+              cluster_address = "edgex-vault:8201"
+          } 
+          backend "file" { 
+              path = "/vault/file" 
+          } 
+          default_lease_ttl = "168h" 
+          max_lease_ttl = "720h"
     volumes:
       - vault-file:/vault/file:z
       - vault-logs:/vault/logs:z
-      - vault-init:/vault/init:ro,z
-      - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
-    depends_on:
-      - security-secrets-setup
-
-  security-secrets-setup:
-    image: ${CORE_EDGEX_REPOSITORY}/docker-security-secrets-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
-    container_name: edgex-secrets-setup
-    hostname: edgex-secrets-setup
-    read_only: true
-    tmpfs:
-      - /tmp
-      - /run
-    command: "generate"
-    volumes:
-      - secrets-setup-cache:/etc/edgex/pki
-      - vault-init:/vault/init:z
-      - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    security_opt: 
-      - no-new-privileges:true
 
   vault-worker:
     image: ${CORE_EDGEX_REPOSITORY}/docker-security-secretstore-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
@@ -99,7 +87,6 @@ services:
       - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     depends_on:
-      - security-secrets-setup
       - consul
       - vault
     security_opt: 
@@ -123,7 +110,6 @@ services:
       - /vault
     volumes:
       - /tmp/edgex/secrets/edgex-security-bootstrap-redis:/tmp/edgex/secrets/edgex-security-bootstrap-redis:ro,z
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     depends_on:
       - vault-worker
       - database
@@ -150,8 +136,6 @@ services:
       POSTGRES_DB: kong
       POSTGRES_USER: kong
       POSTGRES_PASSWORD: ${KONG_POSTGRES_PASSWORD:-kong}
-    depends_on:
-      - security-secrets-setup
     security_opt: 
       - no-new-privileges:true
 
@@ -226,7 +210,6 @@ services:
       SECRETSERVICE_TOKENPATH: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
     volumes:
       - consul-scripts:/consul/scripts:ro,z
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
     depends_on:
       - consul
@@ -243,7 +226,6 @@ services:
     environment:
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-support-notifications/secrets-token.json
     volumes:
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
     depends_on:
       - vault-worker
@@ -255,7 +237,6 @@ services:
     environment:
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-core-metadata/secrets-token.json
     volumes:
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
     depends_on:
       - vault-worker
@@ -267,7 +248,6 @@ services:
     environment:
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-core-data/secrets-token.json
     volumes:
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
     depends_on:
       - vault-worker
@@ -279,7 +259,6 @@ services:
     environment:
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-core-command/secrets-token.json
     volumes:
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
     depends_on:
       - vault-worker
@@ -291,7 +270,6 @@ services:
     environment:
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-support-scheduler/secrets-token.json
     volumes:
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
     depends_on:
       - vault-worker

--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -93,12 +93,9 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
   consul:
     container_name: edgex-core-consul
-    depends_on:
-    - security-secrets-setup
     environment:
       EDGEX_DB: redis
       EDGEX_SECURE: "true"
@@ -116,10 +113,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - consul-scripts:/consul/scripts:z
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
     - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
-    - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
   data:
     container_name: edgex-core-data
     depends_on:
@@ -154,7 +149,6 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
   database:
     container_name: edgex-redis
@@ -272,7 +266,6 @@ services:
     - no-new-privileges:true
     volumes:
     - consul-scripts:/consul/scripts:ro,z
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
   kong:
     command: "/bin/sh -cx \"\n  until /consul/scripts/consul-svc-healthy.sh kong-db;\n\
@@ -315,8 +308,6 @@ services:
     - kong:/usr/local/kong:rw
   kong-db:
     container_name: kong-db
-    depends_on:
-    - security-secrets-setup
     environment:
       POSTGRES_DB: kong
       POSTGRES_PASSWORD: kong
@@ -370,7 +361,6 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
   notifications:
     container_name: edgex-support-notifications
@@ -404,7 +394,6 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
   rulesengine:
     container_name: edgex-kuiper
@@ -464,7 +453,6 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
   security-bootstrap-database:
     container_name: edgex-security-bootstrap-database
@@ -497,23 +485,7 @@ services:
     - /run
     - /vault
     volumes:
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-security-bootstrap-redis:/tmp/edgex/secrets/edgex-security-bootstrap-redis:ro,z
-  security-secrets-setup:
-    command: generate
-    container_name: edgex-secrets-setup
-    hostname: edgex-secrets-setup
-    image: nexus3.edgexfoundry.org:10004/docker-security-secrets-setup-go-arm64:master
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    tmpfs:
-    - /tmp
-    - /run
-    volumes:
-    - secrets-setup-cache:/etc/edgex/pki:rw
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    - vault-init:/vault/init:z
   system:
     container_name: edgex-sys-mgmt-agent
     depends_on:
@@ -552,14 +524,16 @@ services:
   vault:
     cap_add:
     - IPC_LOCK
+    command: server
     container_name: edgex-vault
-    depends_on:
-    - security-secrets-setup
-    entrypoint:
-    - /vault/init/start_vault.sh
     environment:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    tls_disable = \"1\" \n    address\
+        \ = \"edgex-vault:8200\" \n    cluster_address = \"edgex-vault:8201\"\n} \
+        \ backend \"file\" { \n    path = \"/vault/file\" \n}  default_lease_ttl =\
+        \ \"168h\"  max_lease_ttl = \"720h\"\n"
+      VAULT_LOG_LEVEL: INFO
       VAULT_UI: "true"
     hostname: edgex-vault
     image: vault:1.5.3
@@ -570,15 +544,12 @@ services:
     tmpfs:
     - /vault/config
     volumes:
-    - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
     - vault-file:/vault/file:z
-    - vault-init:/vault/init:ro,z
     - vault-logs:/vault/logs:z
   vault-worker:
     container_name: edgex-vault-worker
     depends_on:
     - consul
-    - security-secrets-setup
     - vault
     environment:
       SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
@@ -606,7 +577,6 @@ volumes:
   kuiper-data: {}
   log-data: {}
   postgres-data: {}
-  secrets-setup-cache: {}
   vault-config: {}
   vault-file: {}
   vault-init: {}

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -93,12 +93,9 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
   consul:
     container_name: edgex-core-consul
-    depends_on:
-    - security-secrets-setup
     environment:
       EDGEX_DB: redis
       EDGEX_SECURE: "true"
@@ -116,10 +113,8 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - consul-scripts:/consul/scripts:z
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
     - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
-    - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
   data:
     container_name: edgex-core-data
     depends_on:
@@ -154,7 +149,6 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
   database:
     container_name: edgex-redis
@@ -272,7 +266,6 @@ services:
     - no-new-privileges:true
     volumes:
     - consul-scripts:/consul/scripts:ro,z
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
   kong:
     command: "/bin/sh -cx \"\n  until /consul/scripts/consul-svc-healthy.sh kong-db;\n\
@@ -315,8 +308,6 @@ services:
     - kong:/usr/local/kong:rw
   kong-db:
     container_name: kong-db
-    depends_on:
-    - security-secrets-setup
     environment:
       POSTGRES_DB: kong
       POSTGRES_PASSWORD: kong
@@ -370,7 +361,6 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
   notifications:
     container_name: edgex-support-notifications
@@ -404,7 +394,6 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
   rulesengine:
     container_name: edgex-kuiper
@@ -464,7 +453,6 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
   security-bootstrap-database:
     container_name: edgex-security-bootstrap-database
@@ -497,23 +485,7 @@ services:
     - /run
     - /vault
     volumes:
-    - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-security-bootstrap-redis:/tmp/edgex/secrets/edgex-security-bootstrap-redis:ro,z
-  security-secrets-setup:
-    command: generate
-    container_name: edgex-secrets-setup
-    hostname: edgex-secrets-setup
-    image: nexus3.edgexfoundry.org:10004/docker-security-secrets-setup-go:master
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    tmpfs:
-    - /tmp
-    - /run
-    volumes:
-    - secrets-setup-cache:/etc/edgex/pki:rw
-    - /tmp/edgex/secrets:/tmp/edgex/secrets:z
-    - vault-init:/vault/init:z
   system:
     container_name: edgex-sys-mgmt-agent
     depends_on:
@@ -552,14 +524,16 @@ services:
   vault:
     cap_add:
     - IPC_LOCK
+    command: server
     container_name: edgex-vault
-    depends_on:
-    - security-secrets-setup
-    entrypoint:
-    - /vault/init/start_vault.sh
     environment:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
+      VAULT_LOCAL_CONFIG: "listener \"tcp\" { \n    tls_disable = \"1\" \n    address\
+        \ = \"edgex-vault:8200\" \n    cluster_address = \"edgex-vault:8201\"\n} \
+        \ backend \"file\" { \n    path = \"/vault/file\" \n}  default_lease_ttl =\
+        \ \"168h\"  max_lease_ttl = \"720h\"\n"
+      VAULT_LOG_LEVEL: INFO
       VAULT_UI: "true"
     hostname: edgex-vault
     image: vault:1.5.3
@@ -570,15 +544,12 @@ services:
     tmpfs:
     - /vault/config
     volumes:
-    - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
     - vault-file:/vault/file:z
-    - vault-init:/vault/init:ro,z
     - vault-logs:/vault/logs:z
   vault-worker:
     container_name: edgex-vault-worker
     depends_on:
     - consul
-    - security-secrets-setup
     - vault
     environment:
       SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
@@ -606,7 +577,6 @@ volumes:
   kuiper-data: {}
   log-data: {}
   postgres-data: {}
-  secrets-setup-cache: {}
   vault-config: {}
   vault-file: {}
   vault-init: {}


### PR DESCRIPTION
The security-secrets-setup docker image will be removed once the related PRs removing the secrets-setup component from `edgex-go` and `edgex-core-consul` checkers are merged.

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Current `secrets-setup` is still on docker-compose file.

## Issue Number:  #355 


## What is the new behavior?
No docker `security-secrets-setup` service in the compose files any more

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
Need **two other PRs** to be merged into branch master first for this one to be functioning properly:
 1. edgexfoundry/edgex-go#2913
 1. edgexfoundry/docker-edgex-consul#42

## Other information
To test this locally, you can do the following steps:
1. git clone PR `edgexfoundry/edgex-go#2913` and build the local dev version of docker images: `make docker`
1. git clone PR `edgexfoundry/docker-edgex-consul#42` and build the local version of consul docker image `make docker`
1. git clone this PR and change the directory into `compose-builder`
1. Update the `.env` file under the directory `compose-builder` to use the local versions of built docker images like the followings:
  ```env
RELEASE=nexus
REPOSITORY=edgexfoundry
CORE_EDGEX_REPOSITORY=edgexfoundry
CORE_EDGEX_VERSION=master
CONSUL_VERSION=0.0.0
APP_SERVICE_VERSION=master-dev
DEVICE_BACNET_VERSION=0.0.0-dev
DEVICE_CAMERA_VERSION=0.0.0-dev
DEVICE_GROVE_VERSION=0.0.0-dev
DEVICE_MODBUS_VERSION=0.0.0-dev
DEVICE_MQTT_VERSION=0.0.0-dev
DEVICE_RANDOM_VERSION=0.0.0-dev
DEVICE_REST_VERSION=0.0.0-dev
DEVICE_SNMP_VERSION=0.0.0-dev
DEVICE_VIRTUAL_VERSION=0.0.0-dev
  ```
5.  run `make run dev` so that EdgeX stack is running with local built dev version.
6. observe the docker stack and logs and should look normal and up-and-running.
