### PR TITLE
feat(security): add mock security-bootstrapper

### DIFF
--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -19,6 +19,7 @@
 version: '3.7'
 
 volumes:
+  edgex-init:
   vault-init:
   vault-config:
   vault-file:
@@ -28,13 +29,32 @@ volumes:
   postgres-data:
 
 services:
+  security-bootstrapper:
+    image: gcr.io/google_containers/defaultbackend:1.4
+    container_name: edgex-security-installer
+    hostname: edgex-security-installer
+    networks:
+      - edgex-network
+    volumes:
+      - edgex-init:/edgex-init:z
+
+  database:
+    volumes:
+      - edgex-init:/edgex-init:z
+    depends_on:
+      - security-bootstrapper
+
   consul:
     environment:
       SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
       EDGEX_SECURE: "true"
     volumes:
+      - edgex-init:/edgex-init:z
       - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
       - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
+    depends_on:
+      - security-bootstrapper
+      - vault
 
   vault:
     image: vault:${VAULT_VERSION}
@@ -67,8 +87,11 @@ services:
           default_lease_ttl = "168h" 
           max_lease_ttl = "720h"
     volumes:
+      - edgex-init:/edgex-init:z
       - vault-file:/vault/file:z
       - vault-logs:/vault/logs:z
+    depends_on:
+      - security-bootstrapper
 
   vault-worker:
     image: ${CORE_EDGEX_REPOSITORY}/docker-security-secretstore-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
@@ -83,12 +106,14 @@ services:
       - /run
       - /vault
     volumes:
+      - edgex-init:/edgex-init:z
       - vault-config:/vault/config:z
       - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     depends_on:
-      - consul
+      - security-bootstrapper
       - vault
+      - consul
     security_opt: 
       - no-new-privileges:true
 
@@ -109,8 +134,10 @@ services:
       - /run
       - /vault
     volumes:
+      - edgex-init:/edgex-init:z
       - /tmp/edgex/secrets/edgex-security-bootstrap-redis:/tmp/edgex/secrets/edgex-security-bootstrap-redis:ro,z
     depends_on:
+      - security-bootstrapper
       - vault-worker
       - database
     security_opt: 
@@ -131,11 +158,14 @@ services:
       - /tmp
       - /run
     volumes:
+      - edgex-init:/edgex-init:z
       - postgres-data:/var/lib/postgresql/data:z
     environment:
       POSTGRES_DB: kong
       POSTGRES_USER: kong
       POSTGRES_PASSWORD: ${KONG_POSTGRES_PASSWORD:-kong}
+    depends_on:
+      - security-bootstrapper
     security_opt: 
       - no-new-privileges:true
 
@@ -181,9 +211,11 @@ services:
         done;
         /docker-entrypoint.sh kong docker-start"
     volumes:
+      - edgex-init:/edgex-init:z
       - kong:/usr/local/kong
       - consul-scripts:/consul/scripts:ro,z
     depends_on:
+      - security-bootstrapper
       - consul
       - kong-db
     security_opt: 
@@ -226,8 +258,10 @@ services:
     environment:
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-support-notifications/secrets-token.json
     volumes:
+      - edgex-init:/edgex-init:z
       - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
     depends_on:
+      - security-bootstrapper
       - vault-worker
       - security-bootstrap-database
 
@@ -237,8 +271,10 @@ services:
     environment:
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-core-metadata/secrets-token.json
     volumes:
+      - edgex-init:/edgex-init:z
       - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
     depends_on:
+      - security-bootstrapper
       - vault-worker
       - security-bootstrap-database
 
@@ -248,8 +284,10 @@ services:
     environment:
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-core-data/secrets-token.json
     volumes:
+      - edgex-init:/edgex-init:z
       - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
     depends_on:
+      - security-bootstrapper
       - vault-worker
       - security-bootstrap-database
 
@@ -259,8 +297,10 @@ services:
     environment:
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-core-command/secrets-token.json
     volumes:
+      - edgex-init:/edgex-init:z
       - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
     depends_on:
+      - security-bootstrapper
       - vault-worker
       - security-bootstrap-database
 
@@ -270,7 +310,9 @@ services:
     environment:
       SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/edgex-support-scheduler/secrets-token.json
     volumes:
+      - edgex-init:/edgex-init:z
       - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
     depends_on:
+      - security-bootstrapper
       - vault-worker
       - security-bootstrap-database

--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -67,6 +67,7 @@ services:
     - database
     - metadata
     - security-bootstrap-database
+    - security-bootstrapper
     - vault-worker
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
@@ -93,9 +94,13 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
   consul:
     container_name: edgex-core-consul
+    depends_on:
+    - security-bootstrapper
+    - vault
     environment:
       EDGEX_DB: redis
       EDGEX_SECURE: "true"
@@ -113,6 +118,7 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - consul-scripts:/consul/scripts:z
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
     - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
   data:
@@ -122,6 +128,7 @@ services:
     - database
     - metadata
     - security-bootstrap-database
+    - security-bootstrapper
     - vault-worker
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
@@ -149,9 +156,12 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
   database:
     container_name: edgex-redis
+    depends_on:
+    - security-bootstrapper
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
@@ -175,6 +185,7 @@ services:
     - no-new-privileges:true
     volumes:
     - db-data:/data:z
+    - edgex-init:/edgex-init:z
   device-rest:
     container_name: edgex-device-rest
     depends_on:
@@ -277,6 +288,7 @@ services:
     depends_on:
     - consul
     - kong-db
+    - security-bootstrapper
     environment:
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
@@ -305,9 +317,12 @@ services:
     tty: true
     volumes:
     - consul-scripts:/consul/scripts:ro,z
+    - edgex-init:/edgex-init:z
     - kong:/usr/local/kong:rw
   kong-db:
     container_name: kong-db
+    depends_on:
+    - security-bootstrapper
     environment:
       POSTGRES_DB: kong
       POSTGRES_PASSWORD: kong
@@ -326,6 +341,7 @@ services:
     - /tmp
     - /run
     volumes:
+    - edgex-init:/edgex-init:z
     - postgres-data:/var/lib/postgresql/data:z
   metadata:
     container_name: edgex-core-metadata
@@ -334,6 +350,7 @@ services:
     - database
     - notifications
     - security-bootstrap-database
+    - security-bootstrapper
     - vault-worker
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
@@ -361,6 +378,7 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
   notifications:
     container_name: edgex-support-notifications
@@ -368,6 +386,7 @@ services:
     - consul
     - database
     - security-bootstrap-database
+    - security-bootstrapper
     - vault-worker
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
@@ -394,6 +413,7 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
   rulesengine:
     container_name: edgex-kuiper
@@ -425,6 +445,7 @@ services:
     - consul
     - database
     - security-bootstrap-database
+    - security-bootstrapper
     - vault-worker
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
@@ -453,11 +474,13 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
   security-bootstrap-database:
     container_name: edgex-security-bootstrap-database
     depends_on:
     - database
+    - security-bootstrapper
     - vault-worker
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
@@ -485,7 +508,16 @@ services:
     - /run
     - /vault
     volumes:
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-security-bootstrap-redis:/tmp/edgex/secrets/edgex-security-bootstrap-redis:ro,z
+  security-bootstrapper:
+    container_name: edgex-security-installer
+    hostname: edgex-security-installer
+    image: gcr.io/google_containers/defaultbackend:1.4
+    networks:
+      edgex-network: {}
+    volumes:
+    - edgex-init:/edgex-init:z
   system:
     container_name: edgex-sys-mgmt-agent
     depends_on:
@@ -526,6 +558,8 @@ services:
     - IPC_LOCK
     command: server
     container_name: edgex-vault
+    depends_on:
+    - security-bootstrapper
     environment:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
@@ -544,12 +578,14 @@ services:
     tmpfs:
     - /vault/config
     volumes:
+    - edgex-init:/edgex-init:z
     - vault-file:/vault/file:z
     - vault-logs:/vault/logs:z
   vault-worker:
     container_name: edgex-vault-worker
     depends_on:
     - consul
+    - security-bootstrapper
     - vault
     environment:
       SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
@@ -565,6 +601,7 @@ services:
     - /vault
     volumes:
     - consul-scripts:/consul/scripts:ro,z
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - vault-config:/vault/config:z
 version: '3.7'
@@ -573,6 +610,7 @@ volumes:
   consul-data: {}
   consul-scripts: {}
   db-data: {}
+  edgex-init: {}
   kong: {}
   kuiper-data: {}
   log-data: {}

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -67,6 +67,7 @@ services:
     - database
     - metadata
     - security-bootstrap-database
+    - security-bootstrapper
     - vault-worker
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
@@ -93,9 +94,13 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
   consul:
     container_name: edgex-core-consul
+    depends_on:
+    - security-bootstrapper
+    - vault
     environment:
       EDGEX_DB: redis
       EDGEX_SECURE: "true"
@@ -113,6 +118,7 @@ services:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
     - consul-scripts:/consul/scripts:z
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
     - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
   data:
@@ -122,6 +128,7 @@ services:
     - database
     - metadata
     - security-bootstrap-database
+    - security-bootstrapper
     - vault-worker
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
@@ -149,9 +156,12 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
   database:
     container_name: edgex-redis
+    depends_on:
+    - security-bootstrapper
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
       CLIENTS_COREDATA_HOST: edgex-core-data
@@ -175,6 +185,7 @@ services:
     - no-new-privileges:true
     volumes:
     - db-data:/data:z
+    - edgex-init:/edgex-init:z
   device-rest:
     container_name: edgex-device-rest
     depends_on:
@@ -277,6 +288,7 @@ services:
     depends_on:
     - consul
     - kong-db
+    - security-bootstrapper
     environment:
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
@@ -305,9 +317,12 @@ services:
     tty: true
     volumes:
     - consul-scripts:/consul/scripts:ro,z
+    - edgex-init:/edgex-init:z
     - kong:/usr/local/kong:rw
   kong-db:
     container_name: kong-db
+    depends_on:
+    - security-bootstrapper
     environment:
       POSTGRES_DB: kong
       POSTGRES_PASSWORD: kong
@@ -326,6 +341,7 @@ services:
     - /tmp
     - /run
     volumes:
+    - edgex-init:/edgex-init:z
     - postgres-data:/var/lib/postgresql/data:z
   metadata:
     container_name: edgex-core-metadata
@@ -334,6 +350,7 @@ services:
     - database
     - notifications
     - security-bootstrap-database
+    - security-bootstrapper
     - vault-worker
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
@@ -361,6 +378,7 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
   notifications:
     container_name: edgex-support-notifications
@@ -368,6 +386,7 @@ services:
     - consul
     - database
     - security-bootstrap-database
+    - security-bootstrapper
     - vault-worker
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
@@ -394,6 +413,7 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
   rulesengine:
     container_name: edgex-kuiper
@@ -425,6 +445,7 @@ services:
     - consul
     - database
     - security-bootstrap-database
+    - security-bootstrapper
     - vault-worker
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
@@ -453,11 +474,13 @@ services:
     security_opt:
     - no-new-privileges:true
     volumes:
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
   security-bootstrap-database:
     container_name: edgex-security-bootstrap-database
     depends_on:
     - database
+    - security-bootstrapper
     - vault-worker
     environment:
       CLIENTS_COMMAND_HOST: edgex-core-command
@@ -485,7 +508,16 @@ services:
     - /run
     - /vault
     volumes:
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets/edgex-security-bootstrap-redis:/tmp/edgex/secrets/edgex-security-bootstrap-redis:ro,z
+  security-bootstrapper:
+    container_name: edgex-security-installer
+    hostname: edgex-security-installer
+    image: gcr.io/google_containers/defaultbackend:1.4
+    networks:
+      edgex-network: {}
+    volumes:
+    - edgex-init:/edgex-init:z
   system:
     container_name: edgex-sys-mgmt-agent
     depends_on:
@@ -526,6 +558,8 @@ services:
     - IPC_LOCK
     command: server
     container_name: edgex-vault
+    depends_on:
+    - security-bootstrapper
     environment:
       VAULT_ADDR: http://edgex-vault:8200
       VAULT_CONFIG_DIR: /vault/config
@@ -544,12 +578,14 @@ services:
     tmpfs:
     - /vault/config
     volumes:
+    - edgex-init:/edgex-init:z
     - vault-file:/vault/file:z
     - vault-logs:/vault/logs:z
   vault-worker:
     container_name: edgex-vault-worker
     depends_on:
     - consul
+    - security-bootstrapper
     - vault
     environment:
       SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
@@ -565,6 +601,7 @@ services:
     - /vault
     volumes:
     - consul-scripts:/consul/scripts:ro,z
+    - edgex-init:/edgex-init:z
     - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     - vault-config:/vault/config:z
 version: '3.7'
@@ -573,6 +610,7 @@ volumes:
   consul-data: {}
   consul-scripts: {}
   db-data: {}
+  edgex-init: {}
   kong: {}
   kuiper-data: {}
   log-data: {}


### PR DESCRIPTION
A mock security-bootstrapper added and do nothing for now.
Dependencies on security-bootstrapper for other containers are added in based on the [ADR security bootstrapping](https://github.com/edgexfoundry/edgex-docs/blob/master/docs_src/design/adr/security/0009-Secure-Bootstrapping.md#to-be-startup-flow)  "TO-BE" diagram.
Shared volume `edgex-init` is newly added for preps of future entrypoint script injection from security-bootstrapper.

Closes: #348 

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:  #348 


## What is the new behavior?
A new mock container for secure boostrapping is added. Dependencies also added.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
In draft until removing secrets-setup PR #367  merged and consolidated together.

## Other information