### PR TITLE
feat(security): Set "no-new-privileges" on Svcs

### DIFF
--- a/compose-builder/add-device-bacnet.yml
+++ b/compose-builder/add-device-bacnet.yml
@@ -35,3 +35,5 @@ services:
       - consul
       - data
       - metadata
+    security_opt: 
+      - no-new-privileges:true

--- a/compose-builder/add-device-camera.yml
+++ b/compose-builder/add-device-camera.yml
@@ -36,3 +36,5 @@ services:
       - consul
       - data
       - metadata
+    security_opt: 
+      - no-new-privileges:true

--- a/compose-builder/add-device-grove.yml
+++ b/compose-builder/add-device-grove.yml
@@ -35,3 +35,5 @@ services:
       - consul
       - data
       - metadata
+    security_opt: 
+      - no-new-privileges:true

--- a/compose-builder/add-device-modbus.yml
+++ b/compose-builder/add-device-modbus.yml
@@ -35,3 +35,5 @@ services:
       - consul
       - data
       - metadata
+    security_opt: 
+      - no-new-privileges:true

--- a/compose-builder/add-device-mqtt.yml
+++ b/compose-builder/add-device-mqtt.yml
@@ -38,3 +38,5 @@ services:
       - consul
       - data
       - metadata
+    security_opt: 
+      - no-new-privileges:true

--- a/compose-builder/add-device-random.yml
+++ b/compose-builder/add-device-random.yml
@@ -35,3 +35,5 @@ services:
       - consul
       - data
       - metadata
+    security_opt: 
+      - no-new-privileges:true

--- a/compose-builder/add-device-rest.yml
+++ b/compose-builder/add-device-rest.yml
@@ -36,3 +36,5 @@ services:
       - consul
       - data
       - metadata
+    security_opt: 
+      - no-new-privileges:true

--- a/compose-builder/add-device-snmp.yml
+++ b/compose-builder/add-device-snmp.yml
@@ -35,3 +35,5 @@ services:
       - consul
       - data
       - metadata
+    security_opt: 
+      - no-new-privileges:true

--- a/compose-builder/add-device-virtual.yml
+++ b/compose-builder/add-device-virtual.yml
@@ -35,3 +35,5 @@ services:
       - consul
       - data
       - metadata
+    security_opt: 
+      - no-new-privileges:true

--- a/compose-builder/add-mqtt-messagebus.yml
+++ b/compose-builder/add-mqtt-messagebus.yml
@@ -28,6 +28,8 @@ services:
     read_only: true
     networks:
       - edgex-network
+    security_opt: 
+      - no-new-privileges:true
 
   data:
     environment:

--- a/compose-builder/add-security.yml
+++ b/compose-builder/add-security.yml
@@ -79,6 +79,8 @@ services:
       - secrets-setup-cache:/etc/edgex/pki
       - vault-init:/vault/init:z
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
+    security_opt: 
+      - no-new-privileges:true
 
   vault-worker:
     image: ${CORE_EDGEX_REPOSITORY}/docker-security-secretstore-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
@@ -100,6 +102,8 @@ services:
       - security-secrets-setup
       - consul
       - vault
+    security_opt: 
+      - no-new-privileges:true
 
   security-bootstrap-database:
     image: ${CORE_EDGEX_REPOSITORY}/docker-security-bootstrap-redis-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
@@ -123,6 +127,8 @@ services:
     depends_on:
       - vault-worker
       - database
+    security_opt: 
+      - no-new-privileges:true
 
 # containers for reverse proxy
   kong-db:
@@ -146,6 +152,9 @@ services:
       POSTGRES_PASSWORD: ${KONG_POSTGRES_PASSWORD:-kong}
     depends_on:
       - security-secrets-setup
+    security_opt: 
+      - no-new-privileges:true
+
   kong:
     image: kong:${KONG_VERSION}${KONG_UBUNTU}
     container_name: kong
@@ -193,6 +202,8 @@ services:
     depends_on:
       - consul
       - kong-db
+    security_opt: 
+      - no-new-privileges:true
 
   edgex-proxy:
     image: ${CORE_EDGEX_REPOSITORY}/docker-security-proxy-setup-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
@@ -221,6 +232,8 @@ services:
       - consul
       - vault-worker
       - kong
+    security_opt: 
+      - no-new-privileges:true
 
 # end of containers for reverse proxy
 

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -53,6 +53,8 @@ services:
     environment: 
       EDGEX_DB: redis
       EDGEX_SECURE: "false"
+    security_opt: 
+      - no-new-privileges:true
 
   database:
     image: redis:${REDIS_VERSION}
@@ -67,6 +69,8 @@ services:
       - common.env
     volumes:
       - db-data:/data:z
+    security_opt: 
+      - no-new-privileges:true
 
   system:
     image: ${CORE_EDGEX_REPOSITORY}/docker-sys-mgmt-agent-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
@@ -92,6 +96,8 @@ services:
       - metadata
       - data
       - command
+    security_opt: 
+      - no-new-privileges:true
 
   notifications:
     image: ${CORE_EDGEX_REPOSITORY}/docker-support-notifications-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
@@ -109,6 +115,8 @@ services:
     depends_on:
       - consul
       - database
+    security_opt: 
+      - no-new-privileges:true
 
   metadata:
     image: ${CORE_EDGEX_REPOSITORY}/docker-core-metadata-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
@@ -128,6 +136,8 @@ services:
       - consul
       - database
       - notifications
+    security_opt: 
+      - no-new-privileges:true
 
   data:
     image: ${CORE_EDGEX_REPOSITORY}/docker-core-data-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
@@ -147,6 +157,8 @@ services:
       - consul
       - database
       - metadata
+    security_opt: 
+      - no-new-privileges:true
 
   command:
     image: ${CORE_EDGEX_REPOSITORY}/docker-core-command-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
@@ -165,6 +177,8 @@ services:
       - consul
       - database
       - metadata
+    security_opt: 
+      - no-new-privileges:true
 
   scheduler:
     image: ${CORE_EDGEX_REPOSITORY}/docker-support-scheduler-go${ARCH}:${CORE_EDGEX_VERSION}${DEV}
@@ -184,6 +198,8 @@ services:
     depends_on:
       - consul
       - database
+    security_opt: 
+      - no-new-privileges:true
 
   app-service-rules:
     image: ${REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}
@@ -206,6 +222,8 @@ services:
     depends_on:
       - consul
       - data
+    security_opt: 
+      - no-new-privileges:true
 
   rulesengine:
     image: emqx/kuiper:${KUIPER_VERSION}
@@ -230,3 +248,5 @@ services:
       EDGEX__DEFAULT__PORT: 5566
     depends_on:
       - app-service-rules
+    security_opt: 
+      - no-new-privileges:true

--- a/compose-builder/docker-compose-ui.yml
+++ b/compose-builder/docker-compose-ui.yml
@@ -33,3 +33,5 @@ services:
     read_only: true
     networks:
       - edgex-network
+    security_opt: 
+      - no-new-privileges:true

--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -58,6 +58,8 @@ services:
     ports:
     - 127.0.0.1:48100:48100/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   command:
     container_name: edgex-core-command
     depends_on:
@@ -88,6 +90,8 @@ services:
     ports:
     - 127.0.0.1:48082:48082/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
@@ -106,6 +110,8 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -145,6 +151,8 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:48080:48080/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
@@ -169,6 +177,8 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - db-data:/data:z
   device-rest:
@@ -197,6 +207,8 @@ services:
     ports:
     - 127.0.0.1:49986:49986/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
@@ -222,6 +234,8 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    security_opt:
+    - no-new-privileges:true
   edgex-proxy:
     container_name: edgex-proxy
     depends_on:
@@ -254,6 +268,8 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - consul-scripts:/consul/scripts:ro,z
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
@@ -288,6 +304,8 @@ services:
     - 127.0.0.1:8444:8444/tcp
     read_only: true
     restart: on-failure
+    security_opt:
+    - no-new-privileges:true
     tmpfs:
     - /run
     - /tmp
@@ -310,6 +328,8 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     tmpfs:
     - /var/run
     - /tmp
@@ -347,6 +367,8 @@ services:
     ports:
     - 127.0.0.1:48081:48081/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
@@ -379,6 +401,8 @@ services:
     ports:
     - 127.0.0.1:48060:48060/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
@@ -402,6 +426,8 @@ services:
     - 127.0.0.1:20498:20498/tcp
     - 127.0.0.1:48075:48075/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - kuiper-data:/kuiper/data:z
   scheduler:
@@ -435,6 +461,8 @@ services:
     ports:
     - 127.0.0.1:48085:48085/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
@@ -463,6 +491,8 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     tmpfs:
     - /run
     - /vault
@@ -475,6 +505,8 @@ services:
     hostname: edgex-secrets-setup
     image: nexus3.edgexfoundry.org:10004/docker-security-secrets-setup-go-arm64:master
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     tmpfs:
     - /tmp
     - /run
@@ -513,6 +545,8 @@ services:
     ports:
     - 127.0.0.1:48090:48090/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock:z
   vault:
@@ -553,6 +587,8 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     tmpfs:
     - /run
     - /vault

--- a/releases/nightly-build/compose-files/docker-compose-nexus-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-no-secty-arm64.yml
@@ -58,6 +58,8 @@ services:
     ports:
     - 127.0.0.1:48100:48100/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   command:
     container_name: edgex-core-command
     depends_on:
@@ -84,6 +86,8 @@ services:
     ports:
     - 127.0.0.1:48082:48082/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   consul:
     container_name: edgex-core-consul
     environment:
@@ -96,6 +100,8 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -127,6 +133,8 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:48080:48080/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   database:
     container_name: edgex-redis
     environment:
@@ -148,6 +156,8 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - db-data:/data:z
   device-rest:
@@ -176,6 +186,8 @@ services:
     ports:
     - 127.0.0.1:49986:49986/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
@@ -201,6 +213,8 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    security_opt:
+    - no-new-privileges:true
   metadata:
     container_name: edgex-core-metadata
     depends_on:
@@ -228,6 +242,8 @@ services:
     ports:
     - 127.0.0.1:48081:48081/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   notifications:
     container_name: edgex-support-notifications
     depends_on:
@@ -253,6 +269,8 @@ services:
     ports:
     - 127.0.0.1:48060:48060/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
@@ -273,6 +291,8 @@ services:
     - 127.0.0.1:20498:20498/tcp
     - 127.0.0.1:48075:48075/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - kuiper-data:/kuiper/data:z
   scheduler:
@@ -302,6 +322,8 @@ services:
     ports:
     - 127.0.0.1:48085:48085/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   system:
     container_name: edgex-sys-mgmt-agent
     depends_on:
@@ -333,6 +355,8 @@ services:
     ports:
     - 127.0.0.1:48090:48090/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock:z
 version: '3.7'

--- a/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
@@ -58,6 +58,8 @@ services:
     ports:
     - 127.0.0.1:48100:48100/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   command:
     container_name: edgex-core-command
     depends_on:
@@ -84,6 +86,8 @@ services:
     ports:
     - 127.0.0.1:48082:48082/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   consul:
     container_name: edgex-core-consul
     environment:
@@ -96,6 +100,8 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -127,6 +133,8 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:48080:48080/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   database:
     container_name: edgex-redis
     environment:
@@ -148,6 +156,8 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - db-data:/data:z
   device-rest:
@@ -176,6 +186,8 @@ services:
     ports:
     - 127.0.0.1:49986:49986/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
@@ -201,6 +213,8 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    security_opt:
+    - no-new-privileges:true
   metadata:
     container_name: edgex-core-metadata
     depends_on:
@@ -228,6 +242,8 @@ services:
     ports:
     - 127.0.0.1:48081:48081/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   notifications:
     container_name: edgex-support-notifications
     depends_on:
@@ -253,6 +269,8 @@ services:
     ports:
     - 127.0.0.1:48060:48060/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   rulesengine:
     container_name: edgex-kuiper
     depends_on:
@@ -273,6 +291,8 @@ services:
     - 127.0.0.1:20498:20498/tcp
     - 127.0.0.1:48075:48075/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - kuiper-data:/kuiper/data:z
   scheduler:
@@ -302,6 +322,8 @@ services:
     ports:
     - 127.0.0.1:48085:48085/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   system:
     container_name: edgex-sys-mgmt-agent
     depends_on:
@@ -333,6 +355,8 @@ services:
     ports:
     - 127.0.0.1:48090:48090/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock:z
 version: '3.7'

--- a/releases/nightly-build/compose-files/docker-compose-nexus-ui-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-ui-arm64.yml
@@ -38,5 +38,7 @@ services:
     ports:
     - 127.0.0.1:4000:4000/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
 version: '3.7'
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus-ui.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-ui.yml
@@ -38,5 +38,7 @@ services:
     ports:
     - 127.0.0.1:4000:4000/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
 version: '3.7'
 

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -58,6 +58,8 @@ services:
     ports:
     - 127.0.0.1:48100:48100/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   command:
     container_name: edgex-core-command
     depends_on:
@@ -88,6 +90,8 @@ services:
     ports:
     - 127.0.0.1:48082:48082/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
@@ -106,6 +110,8 @@ services:
     ports:
     - 127.0.0.1:8500:8500/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - consul-config:/consul/config:z
     - consul-data:/consul/data:z
@@ -145,6 +151,8 @@ services:
     - 127.0.0.1:5563:5563/tcp
     - 127.0.0.1:48080:48080/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
@@ -169,6 +177,8 @@ services:
     ports:
     - 127.0.0.1:6379:6379/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - db-data:/data:z
   device-rest:
@@ -197,6 +207,8 @@ services:
     ports:
     - 127.0.0.1:49986:49986/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
   device-virtual:
     container_name: edgex-device-virtual
     depends_on:
@@ -222,6 +234,8 @@ services:
       edgex-network: {}
     ports:
     - 127.0.0.1:49990:49990/tcp
+    security_opt:
+    - no-new-privileges:true
   edgex-proxy:
     container_name: edgex-proxy
     depends_on:
@@ -254,6 +268,8 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - consul-scripts:/consul/scripts:ro,z
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
@@ -288,6 +304,8 @@ services:
     - 127.0.0.1:8444:8444/tcp
     read_only: true
     restart: on-failure
+    security_opt:
+    - no-new-privileges:true
     tmpfs:
     - /run
     - /tmp
@@ -310,6 +328,8 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     tmpfs:
     - /var/run
     - /tmp
@@ -347,6 +367,8 @@ services:
     ports:
     - 127.0.0.1:48081:48081/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
@@ -379,6 +401,8 @@ services:
     ports:
     - 127.0.0.1:48060:48060/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
@@ -402,6 +426,8 @@ services:
     - 127.0.0.1:20498:20498/tcp
     - 127.0.0.1:48075:48075/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - kuiper-data:/kuiper/data:z
   scheduler:
@@ -435,6 +461,8 @@ services:
     ports:
     - 127.0.0.1:48085:48085/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
@@ -463,6 +491,8 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     tmpfs:
     - /run
     - /vault
@@ -475,6 +505,8 @@ services:
     hostname: edgex-secrets-setup
     image: nexus3.edgexfoundry.org:10004/docker-security-secrets-setup-go:master
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     tmpfs:
     - /tmp
     - /run
@@ -513,6 +545,8 @@ services:
     ports:
     - 127.0.0.1:48090:48090/tcp
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock:z
   vault:
@@ -553,6 +587,8 @@ services:
     networks:
       edgex-network: {}
     read_only: true
+    security_opt:
+    - no-new-privileges:true
     tmpfs:
     - /run
     - /vault


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
UIDs within containers running in EdgeX can request and gain elevated privilege which creates a security risk to the processes running within the containers.


## Issue Number:
#143 

## What is the new behavior?
All services, under the orchestration of docker-compose, are now prohibited from gaining elevated privilege through the Docker security option "no-new-privileges" set in the compose service defintions.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
N/A

## Other information