### PR TITLE
feat(build): fix bug of generating incorrect ADD_SECRETSTORE_TOKENS value

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -20,6 +20,7 @@ include .env
 
 COMPOSE_FILES:=-f docker-compose-base.yml
 OPTIONS:=" arm64 no-secty mqtt dev taf-secty taf-no-secty taf-perf taf-perf-no-secty ui ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-random ds-rest ds-snmp ds-virtual modbus-sim asc-http asc-http-s asc-mqtt asc-mqtt-s " # Must have spaces around words for `filter-out` function to work properly
+TOKEN_LIST:=""
 
 ARGS:=$(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(ARGS):;@:)
@@ -79,12 +80,22 @@ ifeq (asc-http, $(filter asc-http,$(ARGS)))
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-http-export.yml
 endif
 ifeq (asc-http-s, $(filter asc-http-s,$(ARGS)))
+    ifeq ($(TOKEN_LIST),"")
+	  TOKEN_LIST:=appservice-http-export-secrets
+	else
+	  TOKEN_LIST:=$(TOKEN_LIST),appservice-http-export-secrets
+	endif
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-http-export-secure.yml
 endif
 ifeq (asc-mqtt, $(filter asc-mqtt,$(ARGS)))
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-mqtt-export.yml
 endif
 ifeq (asc-mqtt-s, $(filter asc-mqtt-s,$(ARGS)))
+    ifeq ($(TOKEN_LIST),"")
+	  TOKEN_LIST:=appservice-mqtt-export-secrets
+	else
+	  TOKEN_LIST:=$(TOKEN_LIST),appservice-mqtt-export-secrets
+	endif
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-mqtt-export-secure.yml
 endif
 
@@ -103,13 +114,13 @@ endif
 
 # Build compose for TAF secure testing (ignore all other compose file options)
 ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
+	TOKEN_LIST:=appservice-http-export-secrets,appservice-mqtt-export-secrets
 	COMPOSE_FILES:= \
 		-f docker-compose-base.yml \
 		-f add-security.yml \
 		-f add-taf-app-services.yml \
 		-f add-asc-http-export-secure.yml \
-		-f add-asc-http-export.yml \
-		-f add-asc-mqtt-export.yml \
+		-f add-asc-mqtt-export-secure.yml \
 		-f add-device-virtual.yml \
 		-f add-device-rest.yml \
 		-f add-device-modbus.yml \
@@ -221,6 +232,7 @@ gen:
 	CORE_EDGEX_VERSION=$(CORE_EDGEX_VERSION) \
 	ARCH=$(ARCH) \
 	KONG_UBUNTU=$(KONG_UBUNTU) \
+	TOKEN_LIST=$(TOKEN_LIST) \
 	docker-compose -p edgex $(COMPOSE_FILES) config > docker-compose.yml
 
 get-token:

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-#  * Copyright 2020 Intel
+#  * Copyright 2021 Intel
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -81,22 +81,22 @@ ifeq (asc-http, $(filter asc-http,$(ARGS)))
 endif
 ifeq (asc-http-s, $(filter asc-http-s,$(ARGS)))
     ifeq ($(TOKEN_LIST),"")
-	  TOKEN_LIST:=appservice-http-export-secrets
-	else
-	  TOKEN_LIST:=$(TOKEN_LIST),appservice-http-export-secrets
-	endif
-	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-http-export-secure.yml
+      TOKEN_LIST:=appservice-http-export-secrets
+    else
+      TOKEN_LIST:=$(TOKEN_LIST),appservice-http-export-secrets
+    endif
+    COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-http-export-secure.yml
 endif
 ifeq (asc-mqtt, $(filter asc-mqtt,$(ARGS)))
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-mqtt-export.yml
 endif
 ifeq (asc-mqtt-s, $(filter asc-mqtt-s,$(ARGS)))
     ifeq ($(TOKEN_LIST),"")
-	  TOKEN_LIST:=appservice-mqtt-export-secrets
-	else
-	  TOKEN_LIST:=$(TOKEN_LIST),appservice-mqtt-export-secrets
-	endif
-	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-mqtt-export-secure.yml
+      TOKEN_LIST:=appservice-mqtt-export-secrets
+    else
+      TOKEN_LIST:=$(TOKEN_LIST),appservice-mqtt-export-secrets
+    endif
+    COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-mqtt-export-secure.yml
 endif
 
 # Add switch to use MQTT Message Bus
@@ -120,7 +120,9 @@ ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
 		-f add-security.yml \
 		-f add-taf-app-services.yml \
 		-f add-asc-http-export-secure.yml \
+		-f add-asc-http-export.yml \
 		-f add-asc-mqtt-export-secure.yml \
+		-f add-asc-mqtt-export.yml \
 		-f add-device-virtual.yml \
 		-f add-device-rest.yml \
 		-f add-device-modbus.yml \
@@ -129,7 +131,7 @@ ifeq (taf-secty, $(filter taf-secty,$(ARGS)))
 		-f add-modbus-simulator.yml
 else
 	# Build compose for TAF non-secure testing (ignore all other compose file options)
-	ifeq (taf-no-secty, $(filter taf-no-secty,$(ARGS)))
+    ifeq (taf-no-secty, $(filter taf-no-secty,$(ARGS)))
 		COMPOSE_FILES:= \
 			-f docker-compose-base.yml \
 			-f add-taf-app-services.yml \
@@ -152,7 +154,7 @@ else
     			-f add-device-virtual.yml \
     			-f add-device-rest.yml \
     			-f add-mqtt-broker.yml
-		else
+    	else
 			# Build compose for TAF non-secure performance testing (ignore all other compose file options)
 			ifeq (taf-perf-no-secty, $(filter taf-perf-no-secty,$(ARGS)))
 				COMPOSE_FILES:= \

--- a/compose-builder/add-asc-http-export-secure.yml
+++ b/compose-builder/add-asc-http-export-secure.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   vault-worker:
     environment:
-      ADD_SECRETSTORE_TOKENS: appservice-http-export-secrets
+      ADD_SECRETSTORE_TOKENS: ${TOKEN_LIST}
 
   app-service-http-export-secrets:
     image: ${REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}

--- a/compose-builder/add-asc-mqtt-export-secure.yml
+++ b/compose-builder/add-asc-mqtt-export-secure.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   vault-worker:
     environment:
-      ADD_SECRETSTORE_TOKENS: appservice-mqtt-export-secrets
+      ADD_SECRETSTORE_TOKENS: ${TOKEN_LIST}
 
   appservice-mqtt-export-secrets:
     image: ${REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-arm64.yml
@@ -57,6 +57,38 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+  app-service-http-export:
+    container_name: app-service-http-export
+    depends_on:
+    - consul
+    - data
+    environment:
+      CLIENTS_COMMAND_HOST: edgex-core-command
+      CLIENTS_COREDATA_HOST: edgex-core-data
+      CLIENTS_DATA_HOST: edgex-core-data
+      CLIENTS_METADATA_HOST: edgex-core-metadata
+      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_RULESENGINE_HOST: edgex-kuiper
+      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
+      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
+      DATABASES_PRIMARY_HOST: edgex-redis
+      EDGEX_PROFILE: http-export
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      REGISTRY_HOST: edgex-core-consul
+      SERVICE_HOST: app-service-http-export
+      SERVICE_PORT: 48101
+      WRITABLE_LOGLEVEL: INFO
+      WRITABLE_PIPELINE_FUNCTIONS_HTTPPOSTJSON_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
+    hostname: app-service-http-export
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
+    networks:
+      edgex-network: {}
+    ports:
+    - 127.0.0.1:48101:48101/tcp
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
   app-service-http-export-secrets:
     container_name: app-service-http-export-secrets
     depends_on:
@@ -96,6 +128,39 @@ services:
     - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/appservice-http-export-secrets:/tmp/edgex/secrets/appservice-http-export-secrets:ro,z
+  app-service-mqtt-export:
+    container_name: app-service-mqtt-export
+    depends_on:
+    - consul
+    - data
+    environment:
+      CLIENTS_COMMAND_HOST: edgex-core-command
+      CLIENTS_COREDATA_HOST: edgex-core-data
+      CLIENTS_DATA_HOST: edgex-core-data
+      CLIENTS_METADATA_HOST: edgex-core-metadata
+      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_RULESENGINE_HOST: edgex-kuiper
+      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
+      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
+      DATABASES_PRIMARY_HOST: edgex-redis
+      EDGEX_PROFILE: mqtt-export
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      REGISTRY_HOST: edgex-core-consul
+      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_PORT: 48103
+      WRITABLE_LOGLEVEL: INFO
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_TOPIC: edgex-events
+    hostname: app-service-mqtt-export
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
+    networks:
+      edgex-network: {}
+    ports:
+    - 127.0.0.1:48103:48103/tcp
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
   app-service-rules:
     container_name: edgex-app-service-configurable-rules
     depends_on:

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-arm64.yml
@@ -57,38 +57,6 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
-  app-service-http-export:
-    container_name: app-service-http-export
-    depends_on:
-    - consul
-    - data
-    environment:
-      CLIENTS_COMMAND_HOST: edgex-core-command
-      CLIENTS_COREDATA_HOST: edgex-core-data
-      CLIENTS_DATA_HOST: edgex-core-data
-      CLIENTS_METADATA_HOST: edgex-core-metadata
-      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_RULESENGINE_HOST: edgex-kuiper
-      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
-      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
-      DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_PROFILE: http-export
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-      REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-http-export
-      SERVICE_PORT: 48101
-      WRITABLE_LOGLEVEL: INFO
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPPOSTJSON_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
-    hostname: app-service-http-export
-    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:48101:48101/tcp
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
   app-service-http-export-secrets:
     container_name: app-service-http-export-secrets
     depends_on:
@@ -128,39 +96,6 @@ services:
     - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/appservice-http-export-secrets:/tmp/edgex/secrets/appservice-http-export-secrets:ro,z
-  app-service-mqtt-export:
-    container_name: app-service-mqtt-export
-    depends_on:
-    - consul
-    - data
-    environment:
-      CLIENTS_COMMAND_HOST: edgex-core-command
-      CLIENTS_COREDATA_HOST: edgex-core-data
-      CLIENTS_DATA_HOST: edgex-core-data
-      CLIENTS_METADATA_HOST: edgex-core-metadata
-      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_RULESENGINE_HOST: edgex-kuiper
-      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
-      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
-      DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_PROFILE: mqtt-export
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-      REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
-      SERVICE_PORT: 48103
-      WRITABLE_LOGLEVEL: INFO
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_TOPIC: edgex-events
-    hostname: app-service-mqtt-export
-    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:48103:48103/tcp
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
   app-service-rules:
     container_name: edgex-app-service-configurable-rules
     depends_on:
@@ -192,6 +127,47 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+  appservice-mqtt-export-secrets:
+    container_name: appservice-mqtt-export-secrets
+    depends_on:
+    - consul
+    - data
+    environment:
+      CLIENTS_COMMAND_HOST: edgex-core-command
+      CLIENTS_COREDATA_HOST: edgex-core-data
+      CLIENTS_DATA_HOST: edgex-core-data
+      CLIENTS_METADATA_HOST: edgex-core-metadata
+      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_RULESENGINE_HOST: edgex-kuiper
+      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
+      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
+      DATABASES_PRIMARY_HOST: edgex-redis
+      EDGEX_PROFILE: mqtt-export
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PATH: /v1/secret/edgex/appservice-mqtt-export-secrets/
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/appservice-mqtt-export-secrets/secrets-token.json
+      SERVICE_HOST: appservice-mqtt-export-secrets
+      SERVICE_PORT: 48104
+      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
+      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
+      WRITABLE_LOGLEVEL: INFO
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_AUTHMODE: usernamepassword
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_TOPIC: edgex-events
+    hostname: appservice-mqtt-export-secrets
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
+    networks:
+      edgex-network: {}
+    ports:
+    - 127.0.0.1:48104:48104/tcp
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    volumes:
+    - /tmp/edgex/secrets/appservice-mqtt-export-secrets:/tmp/edgex/secrets/appservice-mqtt-export-secrets:ro,z
   command:
     container_name: edgex-core-command
     depends_on:
@@ -810,7 +786,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
-      ADD_SECRETSTORE_TOKENS: appservice-http-export-secrets
+      ADD_SECRETSTORE_TOKENS: appservice-http-export-secrets,appservice-mqtt-export-secrets
       SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
     hostname: edgex-vault-worker
     image: nexus3.edgexfoundry.org:10004/docker-security-secretstore-setup-go-arm64:master

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus.yml
@@ -57,6 +57,38 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+  app-service-http-export:
+    container_name: app-service-http-export
+    depends_on:
+    - consul
+    - data
+    environment:
+      CLIENTS_COMMAND_HOST: edgex-core-command
+      CLIENTS_COREDATA_HOST: edgex-core-data
+      CLIENTS_DATA_HOST: edgex-core-data
+      CLIENTS_METADATA_HOST: edgex-core-metadata
+      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_RULESENGINE_HOST: edgex-kuiper
+      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
+      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
+      DATABASES_PRIMARY_HOST: edgex-redis
+      EDGEX_PROFILE: http-export
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      REGISTRY_HOST: edgex-core-consul
+      SERVICE_HOST: app-service-http-export
+      SERVICE_PORT: 48101
+      WRITABLE_LOGLEVEL: INFO
+      WRITABLE_PIPELINE_FUNCTIONS_HTTPPOSTJSON_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
+    hostname: app-service-http-export
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
+    networks:
+      edgex-network: {}
+    ports:
+    - 127.0.0.1:48101:48101/tcp
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
   app-service-http-export-secrets:
     container_name: app-service-http-export-secrets
     depends_on:
@@ -96,6 +128,39 @@ services:
     - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/appservice-http-export-secrets:/tmp/edgex/secrets/appservice-http-export-secrets:ro,z
+  app-service-mqtt-export:
+    container_name: app-service-mqtt-export
+    depends_on:
+    - consul
+    - data
+    environment:
+      CLIENTS_COMMAND_HOST: edgex-core-command
+      CLIENTS_COREDATA_HOST: edgex-core-data
+      CLIENTS_DATA_HOST: edgex-core-data
+      CLIENTS_METADATA_HOST: edgex-core-metadata
+      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_RULESENGINE_HOST: edgex-kuiper
+      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
+      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
+      DATABASES_PRIMARY_HOST: edgex-redis
+      EDGEX_PROFILE: mqtt-export
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      REGISTRY_HOST: edgex-core-consul
+      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_PORT: 48103
+      WRITABLE_LOGLEVEL: INFO
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_TOPIC: edgex-events
+    hostname: app-service-mqtt-export
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
+    networks:
+      edgex-network: {}
+    ports:
+    - 127.0.0.1:48103:48103/tcp
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
   app-service-rules:
     container_name: edgex-app-service-configurable-rules
     depends_on:

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus.yml
@@ -57,38 +57,6 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
-  app-service-http-export:
-    container_name: app-service-http-export
-    depends_on:
-    - consul
-    - data
-    environment:
-      CLIENTS_COMMAND_HOST: edgex-core-command
-      CLIENTS_COREDATA_HOST: edgex-core-data
-      CLIENTS_DATA_HOST: edgex-core-data
-      CLIENTS_METADATA_HOST: edgex-core-metadata
-      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_RULESENGINE_HOST: edgex-kuiper
-      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
-      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
-      DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_PROFILE: http-export
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-      REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-http-export
-      SERVICE_PORT: 48101
-      WRITABLE_LOGLEVEL: INFO
-      WRITABLE_PIPELINE_FUNCTIONS_HTTPPOSTJSON_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
-    hostname: app-service-http-export
-    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:48101:48101/tcp
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
   app-service-http-export-secrets:
     container_name: app-service-http-export-secrets
     depends_on:
@@ -128,39 +96,6 @@ services:
     - no-new-privileges:true
     volumes:
     - /tmp/edgex/secrets/appservice-http-export-secrets:/tmp/edgex/secrets/appservice-http-export-secrets:ro,z
-  app-service-mqtt-export:
-    container_name: app-service-mqtt-export
-    depends_on:
-    - consul
-    - data
-    environment:
-      CLIENTS_COMMAND_HOST: edgex-core-command
-      CLIENTS_COREDATA_HOST: edgex-core-data
-      CLIENTS_DATA_HOST: edgex-core-data
-      CLIENTS_METADATA_HOST: edgex-core-metadata
-      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_RULESENGINE_HOST: edgex-kuiper
-      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
-      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
-      DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_PROFILE: mqtt-export
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-      REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-mqtt-export
-      SERVICE_PORT: 48103
-      WRITABLE_LOGLEVEL: INFO
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
-      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_TOPIC: edgex-events
-    hostname: app-service-mqtt-export
-    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:48103:48103/tcp
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
   app-service-rules:
     container_name: edgex-app-service-configurable-rules
     depends_on:
@@ -192,6 +127,47 @@ services:
     read_only: true
     security_opt:
     - no-new-privileges:true
+  appservice-mqtt-export-secrets:
+    container_name: appservice-mqtt-export-secrets
+    depends_on:
+    - consul
+    - data
+    environment:
+      CLIENTS_COMMAND_HOST: edgex-core-command
+      CLIENTS_COREDATA_HOST: edgex-core-data
+      CLIENTS_DATA_HOST: edgex-core-data
+      CLIENTS_METADATA_HOST: edgex-core-metadata
+      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_RULESENGINE_HOST: edgex-kuiper
+      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
+      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
+      DATABASES_PRIMARY_HOST: edgex-redis
+      EDGEX_PROFILE: mqtt-export
+      EDGEX_SECURITY_SECRET_STORE: "true"
+      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      REGISTRY_HOST: edgex-core-consul
+      SECRETSTORE_HOST: edgex-vault
+      SECRETSTORE_PATH: /v1/secret/edgex/appservice-mqtt-export-secrets/
+      SECRETSTORE_TOKENFILE: /tmp/edgex/secrets/appservice-mqtt-export-secrets/secrets-token.json
+      SERVICE_HOST: appservice-mqtt-export-secrets
+      SERVICE_PORT: 48104
+      WRITABLE_INSECURESECRETS_MQTT_SECRETS_PASSWORD: PASSWORD_PLACE_HOLDER
+      WRITABLE_INSECURESECRETS_MQTT_SECRETS_USERNAME: USERNAME_PLACEH_OLDER
+      WRITABLE_LOGLEVEL: INFO
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_AUTHMODE: usernamepassword
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_TOPIC: edgex-events
+    hostname: appservice-mqtt-export-secrets
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
+    networks:
+      edgex-network: {}
+    ports:
+    - 127.0.0.1:48104:48104/tcp
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    volumes:
+    - /tmp/edgex/secrets/appservice-mqtt-export-secrets:/tmp/edgex/secrets/appservice-mqtt-export-secrets:ro,z
   command:
     container_name: edgex-core-command
     depends_on:
@@ -810,7 +786,7 @@ services:
     - security-bootstrapper
     - vault
     environment:
-      ADD_SECRETSTORE_TOKENS: appservice-http-export-secrets
+      ADD_SECRETSTORE_TOKENS: appservice-http-export-secrets,appservice-mqtt-export-secrets
       SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
     hostname: edgex-vault-worker
     image: nexus3.edgexfoundry.org:10004/docker-security-secretstore-setup-go:master


### PR DESCRIPTION
Makefile with make gen dev asc-http-s asc-mqtt-s now generates the correct ADD_SECRETSTORE_TOKENS value in secure mode.

Fixes: #376
Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
ADD_SECRETSTORE_TOKENS not generated correctly when both asc-http-s and asc-mqtt-s were specified.

## Issue Number: #376 


## What is the new behavior?
ADD_SECRETSTORE_TOKENS now is generated correctly when both asc-http-s and asc-mqtt-s are specified.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information