### PR TITLE
feat(build): Add -dev appendix to app-service-configurable based service image names for make gen app-dev [asc-xxxx]

### DIFF
--- a/compose-builder/.env
+++ b/compose-builder/.env
@@ -24,6 +24,7 @@
 RELEASE=nexus
 REPOSITORY=nexus3.edgexfoundry.org:10004
 CORE_EDGEX_REPOSITORY=nexus3.edgexfoundry.org:10004
+APP_SVC_REPOSITORY=nexus3.edgexfoundry.org:10004
 CORE_EDGEX_VERSION=master
 APP_SERVICE_VERSION=master
 DEVICE_BACNET_VERSION=master

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -29,14 +29,14 @@ $(eval $(ARGS):;@:)
 ifeq (dev, $(filter dev,$(ARGS)))
 	CORE_EDGEX_REPOSITORY=edgexfoundry
 	DEV:=-dev
-	FILE_TAIL_DEV:=$(DEV)
+	FILE_SUFFIX:=$(DEV)
 	# matches the way that edgex-go to versioning the docker images for `make docker`
 	CORE_EDGEX_VERSION:="0.0.0"
 endif
 ifeq (app-dev, $(filter app-dev,$(ARGS)))
 	APP_SVC_REPOSITORY=edgexfoundry
 	APP_SVC_DEV:=-dev
-	FILE_TAIL_DEV:=$(FILE_TAIL_DEV)-app-dev
+	FILE_SUFFIX:=$(FILE_SUFFIX)-app-dev
 endif
 ifeq (arm64, $(filter arm64,$(ARGS)))
 	ARCH:=-arm64
@@ -219,13 +219,13 @@ build:
 	make taf-compose-perf taf-perf-no-secty arm64
 
 compose: gen
-	cat gen-header docker-compose.yml > $(COMPOSE_FOLDER)/docker-compose-$(RELEASE)$(UI)$(NO_SECURITY)$(MQTT)$(ARCH)$(FILE_TAIL_DEV).yml
+	cat gen-header docker-compose.yml > $(COMPOSE_FOLDER)/docker-compose-$(RELEASE)$(UI)$(NO_SECURITY)$(MQTT)$(ARCH)$(FILE_SUFFIX).yml
 
 taf-compose: gen
-	cat gen-header docker-compose.yml > $(TAF_COMPOSE_FOLDER)/docker-compose-taf-$(RELEASE)$(NO_SECURITY)$(MQTT)$(ARCH)$(FILE_TAIL_DEV).yml
+	cat gen-header docker-compose.yml > $(TAF_COMPOSE_FOLDER)/docker-compose-taf-$(RELEASE)$(NO_SECURITY)$(MQTT)$(ARCH)$(FILE_SUFFIX).yml
 
 taf-compose-perf: gen
-	cat gen-header docker-compose.yml > $(TAF_COMPOSE_FOLDER)/docker-compose-taf-perf-$(RELEASE)$(NO_SECURITY)$(MQTT)$(ARCH)$(FILE_TAIL_DEV).yml
+	cat gen-header docker-compose.yml > $(TAF_COMPOSE_FOLDER)/docker-compose-taf-perf-$(RELEASE)$(NO_SECURITY)$(MQTT)$(ARCH)$(FILE_SUFFIX).yml
 
 run: gen
 	docker-compose -p edgex up -d $(SERVICES)

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -19,7 +19,7 @@
 include .env
 
 COMPOSE_FILES:=-f docker-compose-base.yml
-OPTIONS:=" arm64 no-secty mqtt dev taf-secty taf-no-secty taf-perf taf-perf-no-secty ui ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-random ds-rest ds-snmp ds-virtual modbus-sim asc-http asc-http-s asc-mqtt asc-mqtt-s " # Must have spaces around words for `filter-out` function to work properly
+OPTIONS:=" arm64 no-secty mqtt dev app-dev taf-secty taf-no-secty taf-perf taf-perf-no-secty ui ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-random ds-rest ds-snmp ds-virtual modbus-sim asc-http asc-http-s asc-mqtt asc-mqtt-s " # Must have spaces around words for `filter-out` function to work properly
 TOKEN_LIST:=""
 
 ARGS:=$(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
@@ -29,8 +29,14 @@ $(eval $(ARGS):;@:)
 ifeq (dev, $(filter dev,$(ARGS)))
 	CORE_EDGEX_REPOSITORY=edgexfoundry
 	DEV:=-dev
+	FILE_TAIL_DEV:=$(DEV)
 	# matches the way that edgex-go to versioning the docker images for `make docker`
 	CORE_EDGEX_VERSION:="0.0.0"
+endif
+ifeq (app-dev, $(filter app-dev,$(ARGS)))
+	APP_SVC_REPOSITORY=edgexfoundry
+	APP_SVC_DEV:=-dev
+	FILE_TAIL_DEV:=$(FILE_TAIL_DEV)-app-dev
 endif
 ifeq (arm64, $(filter arm64,$(ARGS)))
 	ARCH:=-arm64
@@ -213,13 +219,13 @@ build:
 	make taf-compose-perf taf-perf-no-secty arm64
 
 compose: gen
-	cat gen-header docker-compose.yml > $(COMPOSE_FOLDER)/docker-compose-$(RELEASE)$(UI)$(NO_SECURITY)$(MQTT)$(ARCH)$(DEV).yml
+	cat gen-header docker-compose.yml > $(COMPOSE_FOLDER)/docker-compose-$(RELEASE)$(UI)$(NO_SECURITY)$(MQTT)$(ARCH)$(FILE_TAIL_DEV).yml
 
 taf-compose: gen
-	cat gen-header docker-compose.yml > $(TAF_COMPOSE_FOLDER)/docker-compose-taf-$(RELEASE)$(NO_SECURITY)$(MQTT)$(ARCH)$(DEV).yml
+	cat gen-header docker-compose.yml > $(TAF_COMPOSE_FOLDER)/docker-compose-taf-$(RELEASE)$(NO_SECURITY)$(MQTT)$(ARCH)$(FILE_TAIL_DEV).yml
 
 taf-compose-perf: gen
-	cat gen-header docker-compose.yml > $(TAF_COMPOSE_FOLDER)/docker-compose-taf-perf-$(RELEASE)$(NO_SECURITY)$(MQTT)$(ARCH)$(DEV).yml
+	cat gen-header docker-compose.yml > $(TAF_COMPOSE_FOLDER)/docker-compose-taf-perf-$(RELEASE)$(NO_SECURITY)$(MQTT)$(ARCH)$(FILE_TAIL_DEV).yml
 
 run: gen
 	docker-compose -p edgex up -d $(SERVICES)
@@ -230,8 +236,10 @@ pull: gen
 gen:
 	$(GROVE_CHECK) \
 	DEV=$(DEV) \
+	APP_SVC_DEV=$(APP_SVC_DEV) \
 	CORE_EDGEX_REPOSITORY=$(CORE_EDGEX_REPOSITORY) \
 	CORE_EDGEX_VERSION=$(CORE_EDGEX_VERSION) \
+	APP_SVC_REPOSITORY=$(APP_SVC_REPOSITORY) \
 	ARCH=$(ARCH) \
 	KONG_UBUNTU=$(KONG_UBUNTU) \
 	TOKEN_LIST=$(TOKEN_LIST) \
@@ -249,14 +257,18 @@ upload-tls-cert:
 
 ui-down:
 	DEV= \
+	APP_SVC_DEV= \
 	CORE_EDGEX_REPOSITORY=$(CORE_EDGEX_REPOSITORY) \
+	APP_SVC_REPOSITORY=$(APP_SVC_REPOSITORY) \
 	ARCH= \
 	KONG_UBUNTU= \
 	docker-compose -p edgex -f docker-compose-ui.yml down
 
 down: ui-down
 	DEV= \
+	APP_SVC_DEV= \
 	CORE_EDGEX_REPOSITORY=$(CORE_EDGEX_REPOSITORY) \
+	APP_SVC_REPOSITORY=$(APP_SVC_REPOSITORY) \
 	ARCH= \
 	KONG_UBUNTU= \
 	docker-compose -p edgex \

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -269,6 +269,7 @@ down: ui-down
 	APP_SVC_REPOSITORY=$(APP_SVC_REPOSITORY) \
 	ARCH= \
 	KONG_UBUNTU= \
+	TOKEN_LIST= \
 	docker-compose -p edgex \
 		-f docker-compose-base.yml \
 		-f add-device-bacnet.yml \

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -29,14 +29,12 @@ $(eval $(ARGS):;@:)
 ifeq (dev, $(filter dev,$(ARGS)))
 	CORE_EDGEX_REPOSITORY=edgexfoundry
 	DEV:=-dev
-	FILE_SUFFIX:=$(DEV)
 	# matches the way that edgex-go to versioning the docker images for `make docker`
 	CORE_EDGEX_VERSION:="0.0.0"
 endif
 ifeq (app-dev, $(filter app-dev,$(ARGS)))
 	APP_SVC_REPOSITORY=edgexfoundry
 	APP_SVC_DEV:=-dev
-	FILE_SUFFIX:=$(FILE_SUFFIX)-app-dev
 endif
 ifeq (arm64, $(filter arm64,$(ARGS)))
 	ARCH:=-arm64
@@ -219,13 +217,13 @@ build:
 	make taf-compose-perf taf-perf-no-secty arm64
 
 compose: gen
-	cat gen-header docker-compose.yml > $(COMPOSE_FOLDER)/docker-compose-$(RELEASE)$(UI)$(NO_SECURITY)$(MQTT)$(ARCH)$(FILE_SUFFIX).yml
+	cat gen-header docker-compose.yml > $(COMPOSE_FOLDER)/docker-compose-$(RELEASE)$(UI)$(NO_SECURITY)$(MQTT)$(ARCH).yml
 
 taf-compose: gen
-	cat gen-header docker-compose.yml > $(TAF_COMPOSE_FOLDER)/docker-compose-taf-$(RELEASE)$(NO_SECURITY)$(MQTT)$(ARCH)$(FILE_SUFFIX).yml
+	cat gen-header docker-compose.yml > $(TAF_COMPOSE_FOLDER)/docker-compose-taf-$(RELEASE)$(NO_SECURITY)$(MQTT)$(ARCH).yml
 
 taf-compose-perf: gen
-	cat gen-header docker-compose.yml > $(TAF_COMPOSE_FOLDER)/docker-compose-taf-perf-$(RELEASE)$(NO_SECURITY)$(MQTT)$(ARCH)$(FILE_SUFFIX).yml
+	cat gen-header docker-compose.yml > $(TAF_COMPOSE_FOLDER)/docker-compose-taf-perf-$(RELEASE)$(NO_SECURITY)$(MQTT)$(ARCH).yml
 
 run: gen
 	docker-compose -p edgex up -d $(SERVICES)

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -11,7 +11,7 @@ This folder contains the `Compose Builder` which is made up of **source** compos
 
 Do the following to build compose files for next release such as `hanoi` 
 
-1. Update the `RELEASE`, `REPOSITORY`, `CORE_EDGEX_REPOSITORY` and `versions` contained in the `.env` file.
+1. Update the `RELEASE`, `REPOSITORY`, `CORE_EDGEX_REPOSITORY`, `APP_SVC_REPOSITORY`, and `versions` contained in the `.env` file.
 2. Create the release folder, i.e `release/hanoi/compose-files`
 3. Run `make build` 
 4. Commit changes, open PR and merge PR
@@ -91,7 +91,8 @@ This folder contains the following environment files:
 
 ### Makefile
 
-This folder contains a `Makefile` that provides commands for running, stopping and cleaning the various EdgeX configurations during **development** of the compose files or testing `dev` versions of the service images.
+This folder contains a `Makefile` that provides commands for running, stopping and cleaning the various EdgeX configurations during **development** of the compose files or testing edgex-go's dev version by `dev` argument
+and/or app-service-configurable's dev version by `app-dev` argument for the service images.
 
 ```
 Usage: make <target> where target is:
@@ -132,6 +133,8 @@ Options:
     arm64:      Generates compose file using ARM64 images
     dev:        Generates compose file using local dev built images from edgex-go repo's 
                 'make docker' which creates docker images tagged with '0.0.0-dev'    
+    app-dev:    Generates compose file using local dev built images from app-service-configurable repo's
+                'make docker' which creates docker images tagged with 'master-dev'
     ds-bacnet:  Generates compose file with device-bacnet included
     ds-camera:  Generates compose file with device-camera included
     ds-grove:   Generates compose file with device-grove included (valid only with arm64 option)
@@ -178,6 +181,8 @@ Options:
     arm64:      Runs using ARM64 images    
     dev:        Runs using local dev built images from edgex-go repo's    
                 'make docker' which creates docker images tagged with '0.0.0-dev'
+    app-dev:    Runs using local dev built images from app-service-configurable repo's
+                'make docker' which creates docker images tagged with 'master-dev'
     ds-modbus:  Runs with device-modbus included
     ds-bacnet:  Runs with device-bacnet included
     ds-camera:  Runs with device-camera included
@@ -230,6 +235,8 @@ Options:
     arm64:      Generates compose file using ARM64 images    
     dev:        Generates compose file using local dev built images from edgex-go repo's 
                 'make docker' which creates docker images tagged with '0.0.0-dev'
+    app-dev:    Generates compose file using local dev built images from app-service-configurable repo's
+                'make docker' which creates docker images tagged with 'master-dev'
     ds-modbus:  Generates compose file with device-modbus included
     ds-bacnet:  Generates compose file with device-bacnet included
     ds-camera:  Generates compose file with device-camera included

--- a/compose-builder/add-asc-http-export-secure.yml
+++ b/compose-builder/add-asc-http-export-secure.yml
@@ -6,7 +6,7 @@ services:
       ADD_SECRETSTORE_TOKENS: ${TOKEN_LIST}
 
   app-service-http-export-secrets:
-    image: ${REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}
+    image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
     command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     ports:

--- a/compose-builder/add-asc-http-export.yml
+++ b/compose-builder/add-asc-http-export.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   app-service-http-export:
-    image: ${REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}
+    image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     ports:
       - 127.0.0.1:48101:48101/tcp
     container_name: app-service-http-export

--- a/compose-builder/add-asc-mqtt-export-secure.yml
+++ b/compose-builder/add-asc-mqtt-export-secure.yml
@@ -8,7 +8,7 @@ services:
   appservice-mqtt-export-secrets:
     image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
-    command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"    
+    command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
     ports:
       - 127.0.0.1:48104:48104/tcp
     container_name: app-service-mqtt-export-secrets

--- a/compose-builder/add-asc-mqtt-export-secure.yml
+++ b/compose-builder/add-asc-mqtt-export-secure.yml
@@ -5,10 +5,10 @@ services:
     environment:
       ADD_SECRETSTORE_TOKENS: ${TOKEN_LIST}
 
-  app-service-mqtt-export-secrets:
-    image: ${REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}
+  appservice-mqtt-export-secrets:
+    image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     entrypoint: ["/edgex-init/ready_to_run_wait_install.sh"]
-    command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"
+    command: "/app-service-configurable ${DEFAULT_EDGEX_RUN_CMD_PARMS}"    
     ports:
       - 127.0.0.1:48104:48104/tcp
     container_name: app-service-mqtt-export-secrets

--- a/compose-builder/add-asc-mqtt-export.yml
+++ b/compose-builder/add-asc-mqtt-export.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   app-service-mqtt-export:
-    image: ${REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}
+    image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     ports:
       - 127.0.0.1:48103:48103/tcp
     container_name: app-service-mqtt-export

--- a/compose-builder/add-taf-app-services.yml
+++ b/compose-builder/add-taf-app-services.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   app-service-blackbox-tests:
-    image: ${REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}
+    image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     ports:
       - 48105:48105/tcp
     container_name: app-service-blackbox-tests
@@ -24,7 +24,7 @@ services:
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
 
   scalability-test-mqtt-export:
-    image: ${REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}
+    image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     ports:
       - "48106:48106"
     container_name: scalability-test-mqtt-export

--- a/compose-builder/docker-compose-base.yml
+++ b/compose-builder/docker-compose-base.yml
@@ -1,6 +1,6 @@
 # /*******************************************************************************
 #  * Copyright 2020 Redis Labs Inc.
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at
@@ -202,7 +202,7 @@ services:
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
 
   app-service-rules:
-    image: ${REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}
+    image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     ports:
       - "127.0.0.1:48100:48100"
     container_name: edgex-app-service-configurable-rules

--- a/compose-builder/gen-header
+++ b/compose-builder/gen-header
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-arm64.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/docker-compose-nexus-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-no-secty-arm64.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-no-secty.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/docker-compose-nexus-ui-arm64.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-ui-arm64.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/docker-compose-nexus-ui.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus-ui.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-arm64.yml
@@ -190,7 +190,39 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-mqtt-export-secrets:
+  app-service-rules:
+    container_name: edgex-app-service-configurable-rules
+    depends_on:
+    - consul
+    - data
+    environment:
+      BINDING_PUBLISHTOPIC: events
+      CLIENTS_COMMAND_HOST: edgex-core-command
+      CLIENTS_COREDATA_HOST: edgex-core-data
+      CLIENTS_DATA_HOST: edgex-core-data
+      CLIENTS_METADATA_HOST: edgex-core-metadata
+      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_RULESENGINE_HOST: edgex-kuiper
+      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
+      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
+      DATABASES_PRIMARY_HOST: edgex-redis
+      EDGEX_PROFILE: rules-engine
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      REGISTRY_HOST: edgex-core-consul
+      SERVICE_HOST: edgex-app-service-configurable-rules
+      SERVICE_PORT: 48100
+    hostname: edgex-app-service-configurable-rules
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
+    networks:
+      edgex-network: {}
+    ports:
+    - 127.0.0.1:48100:48100/tcp
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  appservice-mqtt-export-secrets:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
     container_name: app-service-mqtt-export-secrets
@@ -257,38 +289,6 @@ services:
     volumes:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/app-service-mqtt-export-secrets:/tmp/edgex/secrets/app-service-mqtt-export-secrets:ro,z
-  app-service-rules:
-    container_name: edgex-app-service-configurable-rules
-    depends_on:
-    - consul
-    - data
-    environment:
-      BINDING_PUBLISHTOPIC: events
-      CLIENTS_COMMAND_HOST: edgex-core-command
-      CLIENTS_COREDATA_HOST: edgex-core-data
-      CLIENTS_DATA_HOST: edgex-core-data
-      CLIENTS_METADATA_HOST: edgex-core-metadata
-      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_RULESENGINE_HOST: edgex-kuiper
-      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
-      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
-      DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_PROFILE: rules-engine
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-      REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: edgex-app-service-configurable-rules
-      SERVICE_PORT: 48100
-    hostname: edgex-app-service-configurable-rules
-    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:48100:48100/tcp
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
   command:
     command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-command

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-arm64.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-no-secty-arm64.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-no-secty.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-no-secty.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus.yml
@@ -190,7 +190,39 @@ services:
     security_opt:
     - no-new-privileges:true
     user: 2002:2001
-  app-service-mqtt-export-secrets:
+  app-service-rules:
+    container_name: edgex-app-service-configurable-rules
+    depends_on:
+    - consul
+    - data
+    environment:
+      BINDING_PUBLISHTOPIC: events
+      CLIENTS_COMMAND_HOST: edgex-core-command
+      CLIENTS_COREDATA_HOST: edgex-core-data
+      CLIENTS_DATA_HOST: edgex-core-data
+      CLIENTS_METADATA_HOST: edgex-core-metadata
+      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
+      CLIENTS_RULESENGINE_HOST: edgex-kuiper
+      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
+      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
+      DATABASES_PRIMARY_HOST: edgex-redis
+      EDGEX_PROFILE: rules-engine
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      REGISTRY_HOST: edgex-core-consul
+      SERVICE_HOST: edgex-app-service-configurable-rules
+      SERVICE_PORT: 48100
+    hostname: edgex-app-service-configurable-rules
+    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
+    networks:
+      edgex-network: {}
+    ports:
+    - 127.0.0.1:48100:48100/tcp
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    user: 2002:2001
+  appservice-mqtt-export-secrets:
     command: /app-service-configurable -cp=consul.http://edgex-core-consul:8500 --registry
       --confdir=/res
     container_name: app-service-mqtt-export-secrets
@@ -257,38 +289,6 @@ services:
     volumes:
     - edgex-init:/edgex-init:ro,z
     - /tmp/edgex/secrets/app-service-mqtt-export-secrets:/tmp/edgex/secrets/app-service-mqtt-export-secrets:ro,z
-  app-service-rules:
-    container_name: edgex-app-service-configurable-rules
-    depends_on:
-    - consul
-    - data
-    environment:
-      BINDING_PUBLISHTOPIC: events
-      CLIENTS_COMMAND_HOST: edgex-core-command
-      CLIENTS_COREDATA_HOST: edgex-core-data
-      CLIENTS_DATA_HOST: edgex-core-data
-      CLIENTS_METADATA_HOST: edgex-core-metadata
-      CLIENTS_NOTIFICATIONS_HOST: edgex-support-notifications
-      CLIENTS_RULESENGINE_HOST: edgex-kuiper
-      CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
-      CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
-      DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_PROFILE: rules-engine
-      EDGEX_SECURITY_SECRET_STORE: "false"
-      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
-      REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: edgex-app-service-configurable-rules
-      SERVICE_PORT: 48100
-    hostname: edgex-app-service-configurable-rules
-    image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
-    networks:
-      edgex-network: {}
-    ports:
-    - 127.0.0.1:48100:48100/tcp
-    read_only: true
-    security_opt:
-    - no-new-privileges:true
-    user: 2002:2001
   command:
     command: /core-command -cp=consul.http://edgex-core-consul:8500 --registry --confdir=/res
     container_name: edgex-core-command

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-perf-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-perf-nexus-arm64.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-perf-nexus-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-perf-nexus-no-secty-arm64.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-perf-nexus-no-secty.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-perf-nexus-no-secty.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-perf-nexus.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-perf-nexus.yml
@@ -1,4 +1,4 @@
-#  * Copyright 2020 Intel Corporation.
+#  * Copyright 2021 Intel Corporation.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Enhance the capability to have compose file generate `-dev` appendix for the local development version when `make gen app-dev [asc-xxxxxx]`  type of commands is used.

Closes: #380

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently `make gen dev` doesn't generate the image name appended with `-dev` version for `app-service-configurable` type of docker services.


## Issue Number: #380 


## What is the new behavior?
This PR will have `make gen app-dev` generate the image name appended with `-dev` version for `app-service-configurable` type of docker services.  This make local development and testing much easier instead of changing all related env files or compose files everywhere.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information