### PR TITLE
fix: Hanoi - Correct service name and port for device camera

### DIFF
--- a/compose-builder/add-device-camera.yml
+++ b/compose-builder/add-device-camera.yml
@@ -19,10 +19,10 @@
 version: '3.7'
 
 services:
-  device-rest:
+  device-camera:
     image: ${REPOSITORY}/docker-device-camera-go${ARCH}:${DEVICE_CAMERA_VERSION}
     ports:
-      - "127.0.0.1:49986:49986"
+      - "127.0.0.1:49985:49985"
     container_name: edgex-device-camera
     hostname: edgex-device-camera
     read_only: true


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
  `add-device-camera.yml` service name and port conflict with `add-device-rest.yml`

## Issue Number:  #385


## What is the new behavior?
service name and port are set appropriately for device-camera

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information