### PR TITLE
refactor: Rename TAF App Service blockbox-tests to functional-tests

### DIFF
--- a/compose-builder/add-taf-app-services.yml
+++ b/compose-builder/add-taf-app-services.yml
@@ -1,17 +1,17 @@
 version: '3.7'
 
 services:
-  app-service-blackbox-tests:
+  app-service-functional-tests:
     image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}${APP_SVC_DEV}
     ports:
       - 48105:48105/tcp
-    container_name: app-service-blackbox-tests
-    hostname: app-service-blackbox-tests
+    container_name: app-service-functional-tests
+    hostname: app-service-functional-tests
     env_file:
       - common.env
     environment:
-      EDGEX_PROFILE: blackbox-tests
-      SERVICE_HOST: app-service-blackbox-tests
+      EDGEX_PROFILE: functional-tests
+      SERVICE_HOST: app-service-functional-tests
       SERVICE_PORT: 48105
     depends_on:
       - consul

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-arm64.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-arm64.yml
@@ -28,8 +28,8 @@ networks:
   edgex-network:
     driver: bridge
 services:
-  app-service-blackbox-tests:
-    container_name: app-service-blackbox-tests
+  app-service-functional-tests:
+    container_name: app-service-functional-tests
     depends_on:
     - consul
     - data
@@ -43,12 +43,12 @@ services:
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
       DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_PROFILE: blackbox-tests
+      EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-blackbox-tests
+      SERVICE_HOST: app-service-functional-tests
       SERVICE_PORT: 48105
-    hostname: app-service-blackbox-tests
+    hostname: app-service-functional-tests
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
     networks:
       edgex-network: {}

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-no-secty-arm64.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-no-secty-arm64.yml
@@ -28,8 +28,8 @@ networks:
   edgex-network:
     driver: bridge
 services:
-  app-service-blackbox-tests:
-    container_name: app-service-blackbox-tests
+  app-service-functional-tests:
+    container_name: app-service-functional-tests
     depends_on:
     - consul
     - data
@@ -43,12 +43,12 @@ services:
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
       DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_PROFILE: blackbox-tests
+      EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-blackbox-tests
+      SERVICE_HOST: app-service-functional-tests
       SERVICE_PORT: 48105
-    hostname: app-service-blackbox-tests
+    hostname: app-service-functional-tests
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
     networks:
       edgex-network: {}

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-no-secty.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus-no-secty.yml
@@ -28,8 +28,8 @@ networks:
   edgex-network:
     driver: bridge
 services:
-  app-service-blackbox-tests:
-    container_name: app-service-blackbox-tests
+  app-service-functional-tests:
+    container_name: app-service-functional-tests
     depends_on:
     - consul
     - data
@@ -43,12 +43,12 @@ services:
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
       DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_PROFILE: blackbox-tests
+      EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-blackbox-tests
+      SERVICE_HOST: app-service-functional-tests
       SERVICE_PORT: 48105
-    hostname: app-service-blackbox-tests
+    hostname: app-service-functional-tests
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     networks:
       edgex-network: {}

--- a/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus.yml
+++ b/releases/nightly-build/compose-files/taf/docker-compose-taf-nexus.yml
@@ -28,8 +28,8 @@ networks:
   edgex-network:
     driver: bridge
 services:
-  app-service-blackbox-tests:
-    container_name: app-service-blackbox-tests
+  app-service-functional-tests:
+    container_name: app-service-functional-tests
     depends_on:
     - consul
     - data
@@ -43,12 +43,12 @@ services:
       CLIENTS_SCHEDULER_HOST: edgex-support-scheduler
       CLIENTS_VIRTUALDEVICE_HOST: edgex-device-virtual
       DATABASES_PRIMARY_HOST: edgex-redis
-      EDGEX_PROFILE: blackbox-tests
+      EDGEX_PROFILE: functional-tests
       EDGEX_SECURITY_SECRET_STORE: "false"
       REGISTRY_HOST: edgex-core-consul
-      SERVICE_HOST: app-service-blackbox-tests
+      SERVICE_HOST: app-service-functional-tests
       SERVICE_PORT: 48105
-    hostname: app-service-blackbox-tests
+    hostname: app-service-functional-tests
     image: nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
     networks:
       edgex-network: {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
TAF App Service tests use `blackbox-tests` profile which has been renamed to `functional-tests`

## Issue Number: #382


## What is the new behavior?
TAF App Service for function tests has been renamed to `app-service-functional-tests` and the profile changed to use `functional-tests` 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information