### PR TITLE
feat: Add mqtt-broker option to generate compose

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -19,7 +19,7 @@
 include .env
 
 COMPOSE_FILES:=-f docker-compose-base.yml
-OPTIONS:=" arm64 no-secty mqtt dev app-dev taf-secty taf-no-secty taf-perf taf-perf-no-secty ui ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-random ds-rest ds-snmp ds-virtual modbus-sim asc-http asc-http-s asc-mqtt asc-mqtt-s " # Must have spaces around words for `filter-out` function to work properly
+OPTIONS:=" arm64 no-secty mqtt-bus mqtt-broker dev app-dev taf-secty taf-no-secty taf-perf taf-perf-no-secty ui ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-random ds-rest ds-snmp ds-virtual modbus-sim asc-http asc-http-s asc-mqtt asc-mqtt-s " # Must have spaces around words for `filter-out` function to work properly
 TOKEN_LIST:=""
 
 ARGS:=$(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
@@ -103,8 +103,14 @@ ifeq (asc-mqtt-s, $(filter asc-mqtt-s,$(ARGS)))
     COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-mqtt-export-secure.yml
 endif
 
+# Add a MQTT Broker
+ifeq (mqtt-broker, $(filter mqtt-broker,$(ARGS)))
+	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-mqtt-broker.yml
+	MQTT:=-mqtt
+endif
+
 # Add switch to use MQTT Message Bus
-ifeq (mqtt, $(filter mqtt,$(ARGS)))
+ifeq (mqtt-bus, $(filter mqtt-bus,$(ARGS)))
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-mqtt-messagebus.yml -f add-mqtt-broker.yml
 	MQTT:=-mqtt
 endif

--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -19,8 +19,22 @@
 include .env
 
 COMPOSE_FILES:=-f docker-compose-base.yml
-OPTIONS:=" arm64 no-secty mqtt-bus mqtt-broker dev app-dev taf-secty taf-no-secty taf-perf taf-perf-no-secty ui ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-random ds-rest ds-snmp ds-virtual modbus-sim asc-http asc-http-s asc-mqtt asc-mqtt-s " # Must have spaces around words for `filter-out` function to work properly
 TOKEN_LIST:=""
+
+# Must have spaces around words for `filter-out` function to work properly.
+# Dashes at beginning & end of line ensure space before/after the first/last option on that line
+# and don't impact the option list
+define OPTIONS
+ - arm64 no-secty dev app-dev -
+ - mqtt-bus mqtt-broker -
+ - taf-secty taf-no-secty taf-perf taf-perf-no-secty -
+ - ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-random ds-rest ds-snmp ds-virtual -
+ - asc-http asc-http-s asc-mqtt asc-mqtt-s -
+ - modbus-sim ui -
+endef
+export OPTIONS
+
+
 
 ARGS:=$(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(ARGS):;@:)
@@ -184,7 +198,7 @@ ifeq (ui, $(filter ui,$(ARGS)))
 	UI:=-ui
 endif
 
-SERVICES:=$(filter-out $(OPTIONS),$(ARGS))
+SERVICES:=$(filter-out ${OPTIONS},$(ARGS))
 
 ifeq (true, $(DS_GROVE))
  ifneq (-arm64, $(ARCH))
@@ -198,6 +212,7 @@ ifneq (nexus, $(RELEASE))
 endif
 
 help:
+	echo ${OPTIONS}
 	echo "See README.md in this folder"
 
 portainer:

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -138,19 +138,21 @@ Options:
     ds-bacnet:  Generates compose file with device-bacnet included
     ds-camera:  Generates compose file with device-camera included
     ds-grove:   Generates compose file with device-grove included (valid only with arm64 option)
-    ds-modbus:  Generates compose file with device-modbus included
-    ds-mqtt:    Generates compose file with device-mqtt included
-    ds-random:  Generates compose file with device-random included
-    ds-rest:    Generates compose file with device-rest included
-    ds-snmp:    Generates compose file with device-snmp included
-    ds-virtual: Generates compose file with device-virtual included
-    modbus-sim: Generates compose file with ModBus simulator included
-    asc-http:   Generates compose file with App Service HTTP Export included
-    asc-http-s: Generates compose file with App Service HTTP Export Secrets included
-    asc-mqtt:   Generates compose file with App Service MQTT Export included
-    asc-mqtt-s: Generates compose file with App Service MQTT Export Secrets included
-    mqtt:       Generates compose file with services configure for MQTT Message Bus 
-    ui:         Generates stand-alone compose file for EdgeX UI	
+    ds-modbus:   Generates compose file with device-modbus included
+    ds-mqtt:     Generates compose file with device-mqtt included
+    ds-random:   Generates compose file with device-random included
+    ds-rest:     Generates compose file with device-rest included
+    ds-snmp:     Generates compose file with device-snmp included
+    ds-virtual:  Generates compose file with device-virtual included
+    modbus-sim:  Generates compose file with ModBus simulator included
+    asc-http:    Generates compose file with App Service HTTP Export included
+    asc-http-s:  Generates compose file with App Service HTTP Export Secrets included
+    asc-mqtt:    Generates compose file with App Service MQTT Export included
+    asc-mqtt-s:  Generates compose file with App Service MQTT Export Secrets included
+    mqtt-broker: Generates compose file with a MQTT Broker service included 
+    mqtt-bus:    Generates compose file with services configure for MQTT Message Bus 
+                 The MQTT Broker service is also included. 
+    ui:          Generates stand-alone compose file for EdgeX UI	
 ```
 
 ```
@@ -177,28 +179,29 @@ Options:
 run [options] [services]
 Runs the EdgeX services as specified by:
 Options:
-    no-secty:   Runs in Non-Secure Mode, otherwise runs in Secure Mode
-    arm64:      Runs using ARM64 images    
-    dev:        Runs using local dev built images from edgex-go repo's    
-                'make docker' which creates docker images tagged with '0.0.0-dev'
-    app-dev:    Runs using local dev built images from app-service-configurable repo's
-                'make docker' which creates docker images tagged with 'master-dev'
-    ds-modbus:  Runs with device-modbus included
-    ds-bacnet:  Runs with device-bacnet included
-    ds-camera:  Runs with device-camera included
-    ds-grove:   Runs with device-grove included (valid only with arm64 option)
-    ds-mqtt:    Runs with device-mqtt included
-    ds-random:  Runs with device-random included
-    ds-rest:    Runs with device-rest included
-    ds-snmp:    Runs with device-snmp included
-    ds-virtual: Runs with device-virtual included
-    modbus-sim: Runs with ModBus simulator included
-    asc-http:   Runs with App Service HTTP Export included
-    asc-http-s: Runs with App Service HTTP Export Secrets included
-    asc-mqtt:   Runs with App Service MQTT Export included
-    asc-mqtt-s: Runs with App Service MQTT Export Secrets included
-    mqtt:       Runs using MQTT Message Bus
-    ui:         Runs only the EdgeX UI service. `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored. Typically used after the other Edgex Services have been started
+    no-secty:    Runs in Non-Secure Mode, otherwise runs in Secure Mode
+    arm64:       Runs using ARM64 images    
+    dev:         Runs using local dev built images from edgex-go repo's    
+                 'make docker' which creates docker images tagged with '0.0.0-dev'
+    app-dev:     Runs using local dev built images from app-service-configurable repo's
+                 'make docker' which creates docker images tagged with 'master-dev'
+    ds-modbus:   Runs with device-modbus included
+    ds-bacnet:   Runs with device-bacnet included
+    ds-camera:   Runs with device-camera included
+    ds-grove:    Runs with device-grove included (valid only with arm64 option)
+    ds-mqtt:     Runs with device-mqtt included
+    ds-random:   Runs with device-random included
+    ds-rest:     Runs with device-rest included
+    ds-snmp:     Runs with device-snmp included
+    ds-virtual:  Runs with device-virtual included
+    modbus-sim:  Runs with ModBus simulator included
+    asc-http:    Runs with App Service HTTP Export included
+    asc-http-s:  Runs with App Service HTTP Export Secrets included
+    asc-mqtt:    Runs with App Service MQTT Export included
+    asc-mqtt-s:  Runs with App Service MQTT Export Secrets included
+    mqtt-broker: Runs with a MQTT Broker service included 
+    mqtt-bus:    Runs with services configure for MQTT Message Bus 
+    ui:          Runs only the EdgeX UI service. `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored. Typically used after the other Edgex Services have been started
 Services:
     <names...>: Runs only services listed (and their dependent services) where 'name' matches a service name in one of the compose files used
 ```
@@ -206,24 +209,25 @@ Services:
 pull [options] [services]
 Pulls the EdgeX service images as specified by:
 Options:
-    no-secty:   Pulls images for Non-Secure Mode, otherwise pull images for Secure Mode
-    arm64:      Pulls ARM64 version of images    
-    ds-bacnet:  Pull includes device-bacnet 
-    ds-camera:  Pull includes device-camera
-    ds-grove:   Pull includes device-grove (valid only with arm64 option)
-    ds-modbus:  Pull includes device-modbus 
-    ds-mqtt:    Pull includes device-mqtt
-    ds-random:  Pull includes device-random
-    ds-rest:    Pull includes device-rest
-    ds-snmp:    Pull includes device-snmp
-    ds-virtual: Pull includes device-virtual
-    modbus-sim: Pull includes ModBus simulator
-    asc-http:   Pull includes App Service HTTP Export
-    asc-http-s: Pull includes App Service HTTP Export Secrets
-    asc-mqtt:   Pull includes App Service MQTT Export
-    asc-mqtt-s: Pull includes App Service MQTT Export Secrets
-    mqtt:       Pull includes additional service for MQTT Message Bus
-    ui:         Pulls only the EdgeX UI service image. `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored
+    no-secty:    Pulls images for Non-Secure Mode, otherwise pull images for Secure Mode
+    arm64:       Pulls ARM64 version of images    
+    ds-bacnet:   Pull includes device-bacnet 
+    ds-camera:   Pull includes device-camera
+    ds-grove:    Pull includes device-grove (valid only with arm64 option)
+    ds-modbus:   Pull includes device-modbus 
+    ds-mqtt:     Pull includes device-mqtt
+    ds-random:   Pull includes device-random
+    ds-rest:     Pull includes device-rest
+    ds-snmp:     Pull includes device-snmp
+    ds-virtual:  Pull includes device-virtual
+    modbus-sim:  Pull includes ModBus simulator
+    asc-http:    Pull includes App Service HTTP Export
+    asc-http-s:  Pull includes App Service HTTP Export Secrets
+    asc-mqtt:    Pull includes App Service MQTT Export
+    asc-mqtt-s:  Pull includes App Service MQTT Export Secrets
+    mqtt-broker: Pull includes MQTT Broker service
+    mqtt-bus:    Pull includes additional service for MQTT Message Bus
+    ui:          Pulls only the EdgeX UI service image. `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored
 Services:
     <names...>: Pulls only images for the service(s) listed
 ```
@@ -241,18 +245,20 @@ Options:
     ds-bacnet:  Generates compose file with device-bacnet included
     ds-camera:  Generates compose file with device-camera included
     ds-grove:   Generates compose file with device-grove included (valid only with arm64 option)
-    ds-mqtt:    Generates compose file with device-mqtt included
-    ds-random:  Generates compose file with device-random included
-    ds-rest:    Generates compose file with device-rest included
-    ds-snmp:    Generates compose file with device-snmp included
-    ds-virtual: Generates compose file with device-virtual included
-    modbus-sim: Generates compose file with ModBus simulator included
-    asc-http:   Generates compose file with App Service HTTP Export included
-    asc-http-s: Generates compose file with App Service HTTP Export Secrets included
-    asc-mqtt:   Generates compose file with App Service MQTT Export included
-    asc-mqtt-s: Generates compose file with App Service MQTT Export Secrets included
-    mqtt:       Generates compose file configured to use MQTT Message Bus
-    ui:         Generates stand-alone compose file for EdgeX UI
+    ds-mqtt:     Generates compose file with device-mqtt included
+    ds-random:   Generates compose file with device-random included
+    ds-rest:     Generates compose file with device-rest included
+    ds-snmp:     Generates compose file with device-snmp included
+    ds-virtual:  Generates compose file with device-virtual included
+    modbus-sim:  Generates compose file with ModBus simulator included
+    asc-http:    Generates compose file with App Service HTTP Export included
+    asc-http-s:  Generates compose file with App Service HTTP Export Secrets included
+    asc-mqtt:    Generates compose file with App Service MQTT Export included
+    asc-mqtt-s:  Generates compose file with App Service MQTT Export Secrets included
+    mqtt-broker: Generates compose file with a MQTT Broker service included 
+    mqtt-bus:    Generates compose file with services configure for MQTT Message Bus 
+                 The MQTT Broker service is also included. 
+    ui:          Generates stand-alone compose file for EdgeX UI
 ```
 ```
 get-token [options] 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
No option to simply add a MQTT Broker. The current `mqtt` option adds a broker but also reconfigures the message bus,

## Issue Number: #404

## What is the new behavior?
New `mqtt-broker option simply adds the additional MQTT Broker service

Previous `mqtt` option renamed `mqtt-bus` to be more explicit.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information