### PR TITLE
feat: Hanoi - Add new compose builder options for 1.3.1

### DIFF
--- a/compose-builder/Makefile
+++ b/compose-builder/Makefile
@@ -19,7 +19,18 @@
 include .env
 
 COMPOSE_FILES:=-f docker-compose-base.yml
-OPTIONS:=" arm64 no-secty mqtt dev ui ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-random ds-rest ds-snmp ds-virtual " # Must have spaces around words for `filter-out` function to work properly
+
+# Must have spaces around words for `filter-out` function to work properly.
+# Dashes at beginning & end of line ensure space before/after the first/last option on that line
+# and don't impact the option list
+define OPTIONS
+ - arm64 no-secty dev -
+ - mqtt-bus mqtt-broker -
+ - ds-bacnet ds-camera ds-grove ds-modbus ds-mqtt ds-random ds-rest ds-snmp ds-virtual -
+ - asc-http asc-mqtt  -
+ - modbus-sim ui -
+endef
+export OPTIONS
 
 ARGS:=$(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(ARGS):;@:)
@@ -64,23 +75,46 @@ endif
 ifeq (ds-virtual, $(filter ds-virtual,$(ARGS)))
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-device-virtual.yml
 endif
-# Add/switch to use MQTT Message Bus
-ifeq (mqtt, $(filter mqtt,$(ARGS)))
-	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-mqtt-messagebus.yml
+
+# Add ModBus Simulator
+ifeq (modbus-sim, $(filter modbus-sim,$(ARGS)))
+	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-modbus-simulator.yml
+endif
+
+# Add Application Services
+ifeq (asc-http, $(filter asc-http,$(ARGS)))
+	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-http-export.yml
+endif
+ifeq (asc-mqtt, $(filter asc-mqtt,$(ARGS)))
+	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-asc-mqtt-export.yml
+endif
+
+# Add a MQTT Broker
+ifeq (mqtt-broker, $(filter mqtt-broker,$(ARGS)))
+	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-mqtt-broker.yml
 	MQTT:=-mqtt
 endif
+
+# Add switch to use MQTT Message Bus
+ifeq (mqtt-bus, $(filter mqtt-bus,$(ARGS)))
+	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-mqtt-messagebus.yml -f add-mqtt-broker.yml
+	MQTT:=-mqtt
+endif
+
 # Add Security services and settings
 ifeq (no-secty, $(filter no-secty,$(ARGS)))
 	NO_SECURITY:=-no-secty
 else
 	COMPOSE_FILES:=$(COMPOSE_FILES) -f add-security.yml
 endif
+
+# Just the UI
 ifeq (ui, $(filter ui,$(ARGS)))
 	COMPOSE_FILES:=-f docker-compose-ui.yml
 	UI:=-ui
 endif
 
-SERVICES:=$(filter-out $(OPTIONS),$(ARGS))
+SERVICES:=$(filter-out ${OPTIONS},$(ARGS))
 
 ifeq (true, $(DS_GROVE))
  ifneq (-arm64, $(ARCH))
@@ -165,7 +199,11 @@ down: ui-down
 		-f add-device-rest.yml \
 		-f add-device-snmp.yml \
 		-f add-device-virtual.yml \
+		-f add-asc-http-export.yml \
+		-f add-asc-mqtt-export.yml \
+		-f add-mqtt-broker.yml \
 		-f add-mqtt-messagebus.yml \
+		-f add-modbus-simulator.yml \
 		-f add-security.yml \
 		down
 

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -123,9 +123,7 @@ Options:
     ds-virtual:  Generates compose file with device-virtual included
     modbus-sim:  Generates compose file with ModBus simulator included
     asc-http:    Generates compose file with App Service HTTP Export included
-    asc-http-s:  Generates compose file with App Service HTTP Export Secrets included
     asc-mqtt:    Generates compose file with App Service MQTT Export included
-    asc-mqtt-s:  Generates compose file with App Service MQTT Export Secrets included
     mqtt-broker: Generates compose file with a MQTT Broker service included 
     mqtt-bus:    Generates compose file with services configure for MQTT Message Bus 
                  The MQTT Broker service is also included. 
@@ -151,9 +149,7 @@ Options:
     ds-virtual:  Runs device-virtual included
     modbus-sim:  Runs with ModBus simulator included
     asc-http:    Runs with App Service HTTP Export included
-    asc-http-s:  Runs with App Service HTTP Export Secrets included
     asc-mqtt:    Runs with App Service MQTT Export included
-    asc-mqtt-s:  Runs with App Service MQTT Export Secrets included
     mqtt-broker: Runs with a MQTT Broker service included 
     mqtt-bus:    Runs with services configure for MQTT Message Bus 
     ui:          Runs only the EdgeX UI service. `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored. Typically used after the other Edgex Services have been started
@@ -177,9 +173,7 @@ Options:
     ds-virtual:  Pull includes device-virtual
     modbus-sim:  Pull includes ModBus simulator
     asc-http:    Pull includes App Service HTTP Export
-    asc-http-s:  Pull includes App Service HTTP Export Secrets
     asc-mqtt:    Pull includes App Service MQTT Export
-    asc-mqtt-s:  Pull includes App Service MQTT Export Secrets
     mqtt-broker: Pull includes MQTT Broker service
     mqtt-bus:    Pull includes additional service for MQTT Message Bus
     ui:          Pulls only the EdgeX UI service image. `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored
@@ -205,9 +199,7 @@ Options:
     ds-virtual:  Generates compose file with device-virtual included
     modbus-sim:  Generates compose file with ModBus simulator included
     asc-http:    Generates compose file with App Service HTTP Export included
-    asc-http-s:  Generates compose file with App Service HTTP Export Secrets included
     asc-mqtt:    Generates compose file with App Service MQTT Export included
-    asc-mqtt-s:  Generates compose file with App Service MQTT Export Secrets included
     mqtt-broker: Generates compose file with a MQTT Broker service included 
     mqtt-bus:    Generates compose file with services configure for MQTT Message Bus 
                  The MQTT Broker service is also included. 

--- a/compose-builder/README.md
+++ b/compose-builder/README.md
@@ -55,6 +55,14 @@ This folder contains the following compose files:
     Device Service **extending** compose file, which adds the **Device SNMP**  service.
 - **add-device-virtual.yml**
     Device Service **extending** compose file, which adds the **Device Virtual**  service.
+- **add-asc-http-export.yml**
+    Application Service Configurable **extending** compose file, which adds the **App Service Http Export**  service.
+- **add-asc-mqtt-export.yml**
+    Application Service Configurable **extending** compose file, which adds the **App Service MQTT Export**  service.
+- **add-modbus-simulator.yml**
+    ModBus Simulator **extending** compose file. Adds the MQTT ModBus Simulator service. Must be used in conjunction with  **add-device-modbus.yml**
+- **add-mqtt-broker.yml**
+    MQTT Broker **extending** compose file. Adds the Eclipse Mosquitto MQTT Broker.
 - **add-mqtt-messagebus.yml**
     MQTT **extending** compose file. Adds a MQTT Broker and additional configuration of services so that the `MQTT` implementation of the Edgex Message Bus is used.
 - **docker-compose-ui.yml**
@@ -100,42 +108,55 @@ compose [options]
 Generates the EdgeX compose file as specified by options and stores them in the configured relese folder. Compose files are named appropriatly for release and options used to generate them.
 
 Options:
-    no-secty:   Generates non-secure compose file, otherwise generates secure compose file
-    arm64:      Generates compose file using ARM64 images
-    dev:        Generates compose file using local dev built images from edgex-go repo's 
-                'make docker' which creates docker images tagged with '0.0.0-dev'    
-    ds-bacnet:  Generates compose file with device-bacnet included
-    ds-camera:  Generates compose file with device-camera included
-    ds-grove:   Generates compose file with device-grove included (valid only with arm64 option)
-    ds-modbus:  Generates compose file with device-modbus included
-    ds-mqtt:    Generates compose file with device-mqtt included
-    ds-random:  Generates compose file with device-random included
-    ds-rest:    Generates compose file with device-rest included
-    ds-snmp:    Generates compose file with device-snmp included
-    ds-virtual: Generates compose file with device-virtual included
-    mqtt:       Generates compose file with services configure for MQTT Message Bus 
-    ui:         Generates stand-alone compose file for EdgeX UI	
+    no-secty:    Generates non-secure compose file, otherwise generates secure compose file
+    arm64:       Generates compose file using ARM64 images
+    dev:         Generates compose file using local dev built images from edgex-go repo's 
+                 'make docker' which creates docker images tagged with '0.0.0-dev'    
+    ds-bacnet:   Generates compose file with device-bacnet included
+    ds-camera:   Generates compose file with device-camera included
+    ds-grove:    Generates compose file with device-grove included (valid only with arm64 option)
+    ds-modbus:   Generates compose file with device-modbus included
+    ds-mqtt:     Generates compose file with device-mqtt included
+    ds-random:   Generates compose file with device-random included
+    ds-rest:     Generates compose file with device-rest included
+    ds-snmp:     Generates compose file with device-snmp included
+    ds-virtual:  Generates compose file with device-virtual included
+    modbus-sim:  Generates compose file with ModBus simulator included
+    asc-http:    Generates compose file with App Service HTTP Export included
+    asc-http-s:  Generates compose file with App Service HTTP Export Secrets included
+    asc-mqtt:    Generates compose file with App Service MQTT Export included
+    asc-mqtt-s:  Generates compose file with App Service MQTT Export Secrets included
+    mqtt-broker: Generates compose file with a MQTT Broker service included 
+    mqtt-bus:    Generates compose file with services configure for MQTT Message Bus 
+                 The MQTT Broker service is also included. 
+    ui:          Generates stand-alone compose file for EdgeX UI	
 ```
 
 ```
 run [options] [services]
 Runs the EdgeX services as specified by:
 Options:
-    no-secty:   Runs in Non-Secure Mode, otherwise runs in Secure Mode
-    arm64:      Runs using ARM64 images    
-    dev:        Runs using local dev built images from edgex-go repo's    
-                'make docker' which creates docker images tagged with '0.0.0-dev'
-    ds-modbus:  Runs with device-modbus included
-    ds-bacnet:  Runs with device-bacnet included
-    ds-camera:  Runs with device-camera included
-    ds-grove:   Runs with device-grove included (valid only with arm64 option)
-    ds-mqtt:    Runs with device-mqtt included
-    ds-random:  Runs with device-random included
-    ds-rest:    Runs with device-rest included
-    ds-snmp:    Runs with device-snmp included
-    ds-virtual: Runs device-virtual included
-    mqtt:       Runs using MQTT Message Bus
-    ui:         Runs only the EdgeX UI service. `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored. Typically used after the other Edgex Services have been started
+    no-secty:    Runs in Non-Secure Mode, otherwise runs in Secure Mode
+    arm64:       Runs using ARM64 images    
+    dev:         Runs using local dev built images from edgex-go repo's    
+                 'make docker' which creates docker images tagged with '0.0.0-dev'
+    ds-modbus:   Runs with device-modbus included
+    ds-bacnet:   Runs with device-bacnet included
+    ds-camera:   Runs with device-camera included
+    ds-grove:    Runs with device-grove included (valid only with arm64 option)
+    ds-mqtt:     Runs with device-mqtt included
+    ds-random:   Runs with device-random included
+    ds-rest:     Runs with device-rest included
+    ds-snmp:     Runs with device-snmp included
+    ds-virtual:  Runs device-virtual included
+    modbus-sim:  Runs with ModBus simulator included
+    asc-http:    Runs with App Service HTTP Export included
+    asc-http-s:  Runs with App Service HTTP Export Secrets included
+    asc-mqtt:    Runs with App Service MQTT Export included
+    asc-mqtt-s:  Runs with App Service MQTT Export Secrets included
+    mqtt-broker: Runs with a MQTT Broker service included 
+    mqtt-bus:    Runs with services configure for MQTT Message Bus 
+    ui:          Runs only the EdgeX UI service. `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored. Typically used after the other Edgex Services have been started
 Services:
     <names...>: Runs only services listed (and their dependent services) where 'name' matches a service name in one of the compose files used
 ```
@@ -143,19 +164,25 @@ Services:
 pull [options] [services]
 Pulls the EdgeX service images as specified by:
 Options:
-    no-secty:   Pulls images for Non-Secure Mode, otherwise pull images for Secure Mode
-    arm64:      Pulls ARM64 version of images    
-    ds-bacnet:  Pull includes device-bacnet 
-    ds-camera:  Pull includes device-camera
-    ds-grove:   Pull includes device-grove (valid only with arm64 option)
-    ds-modbus:  Pull includes device-modbus 
-    ds-mqtt:    Pull includes device-mqtt
-    ds-random:  Pull includes device-random
-    ds-rest:    Pull includes device-rest
-    ds-snmp:    Pull includes device-snmp
-    ds-virtual: Pull includes device-virtual
-    mqtt:       Pulls included additional service for MQTT Message Bus 
-    ui:         Pulls only the EdgeX UI service image. `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored
+    no-secty:    Pulls images for Non-Secure Mode, otherwise pull images for Secure Mode
+    arm64:       Pulls ARM64 version of images    
+    ds-bacnet:   Pull includes device-bacnet 
+    ds-camera:   Pull includes device-camera
+    ds-grove:    Pull includes device-grove (valid only with arm64 option)
+    ds-modbus:   Pull includes device-modbus 
+    ds-mqtt:     Pull includes device-mqtt
+    ds-random:   Pull includes device-random
+    ds-rest:     Pull includes device-rest
+    ds-snmp:     Pull includes device-snmp
+    ds-virtual:  Pull includes device-virtual
+    modbus-sim:  Pull includes ModBus simulator
+    asc-http:    Pull includes App Service HTTP Export
+    asc-http-s:  Pull includes App Service HTTP Export Secrets
+    asc-mqtt:    Pull includes App Service MQTT Export
+    asc-mqtt-s:  Pull includes App Service MQTT Export Secrets
+    mqtt-broker: Pull includes MQTT Broker service
+    mqtt-bus:    Pull includes additional service for MQTT Message Bus
+    ui:          Pulls only the EdgeX UI service image. `ds-x`, 'mqtt', 'no-ds' & 'no-secty' are ignored
 Services:
     <names...>: Pulls only images for the service(s) listed
 ```
@@ -163,21 +190,28 @@ Services:
 gen [options]
 Generates temporary single file compose file (`docker-compose.yml`) as specified by:
 Options:
-    no-secty:   Generates non-secure compose, otherwise generates secure compose file
-    arm64:      Generates compose file using ARM64 images    
-    dev:        Generates compose file using local dev built images from edgex-go repo's 
-                'make docker' which creates docker images tagged with '0.0.0-dev'
-    ds-modbus:  Generates compose file with device-modbus included
-    ds-bacnet:  Generates compose file with device-bacnet included
-    ds-camera:  Generates compose file with device-camera included
-    ds-grove:   Generates compose file with device-grove included (valid only with arm64 option)
-    ds-mqtt:    Generates compose file with device-mqtt included
-    ds-random:  Generates compose file with device-random included
-    ds-rest:    Generates compose file with device-rest included
-    ds-snmp:    Generates compose file with device-snmp included
-    ds-virtual: Generates compose file with device-virtual included
-    mqtt:       Generates compose file configured to use MQTT Message Bus
-    ui:         Generates stand-alone compose file for EdgeX UI
+    no-secty:    Generates non-secure compose, otherwise generates secure compose file
+    arm64:       Generates compose file using ARM64 images    
+    dev:         Generates compose file using local dev built images from edgex-go repo's 
+                 'make docker' which creates docker images tagged with '0.0.0-dev'
+    ds-modbus:   Generates compose file with device-modbus included
+    ds-bacnet:   Generates compose file with device-bacnet included
+    ds-camera:   Generates compose file with device-camera included
+    ds-grove:    Generates compose file with device-grove included (valid only with arm64 option)
+    ds-mqtt:     Generates compose file with device-mqtt included
+    ds-random:   Generates compose file with device-random included
+    ds-rest:     Generates compose file with device-rest included
+    ds-snmp:     Generates compose file with device-snmp included
+    ds-virtual:  Generates compose file with device-virtual included
+    modbus-sim:  Generates compose file with ModBus simulator included
+    asc-http:    Generates compose file with App Service HTTP Export included
+    asc-http-s:  Generates compose file with App Service HTTP Export Secrets included
+    asc-mqtt:    Generates compose file with App Service MQTT Export included
+    asc-mqtt-s:  Generates compose file with App Service MQTT Export Secrets included
+    mqtt-broker: Generates compose file with a MQTT Broker service included 
+    mqtt-bus:    Generates compose file with services configure for MQTT Message Bus 
+                 The MQTT Broker service is also included. 
+    ui:          Generates stand-alone compose file for EdgeX UI
 ```
 ```
 get-token [options] 

--- a/compose-builder/add-asc-http-export.yml
+++ b/compose-builder/add-asc-http-export.yml
@@ -1,0 +1,26 @@
+version: '3.7'
+
+services:
+  app-service-http-export:
+    image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}
+    ports:
+      - 127.0.0.1:48101:48101/tcp
+    container_name: app-service-http-export
+    hostname: app-service-http-export
+    env_file:
+      - common.env
+    environment:
+      EDGEX_PROFILE: http-export
+      SERVICE_HOST: app-service-http-export
+      SERVICE_PORT: 48101
+      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      WRITABLE_PIPELINE_FUNCTIONS_HTTPPOSTJSON_PARAMETERS_URL: http://EXPORT_HOST_PLACE_HOLDER:7770
+      WRITABLE_LOGLEVEL: INFO # allows scripts to find and change with sed
+    depends_on:
+      - consul
+      - data
+    read_only: true
+    networks:
+      - edgex-network
+    security_opt:
+      - no-new-privileges:true

--- a/compose-builder/add-asc-mqtt-export.yml
+++ b/compose-builder/add-asc-mqtt-export.yml
@@ -1,0 +1,27 @@
+version: '3.7'
+
+services:
+  app-service-mqtt-export:
+    image: ${APP_SVC_REPOSITORY}/docker-app-service-configurable${ARCH}:${APP_SERVICE_VERSION}
+    ports:
+      - 127.0.0.1:48103:48103/tcp
+    container_name: app-service-mqtt-export
+    hostname: app-service-mqtt-export
+    env_file:
+      - common.env
+    environment:
+      EDGEX_PROFILE: mqtt-export
+      SERVICE_HOST: app-service-mqtt-export
+      SERVICE_PORT: 48103
+      MESSAGEBUS_SUBSCRIBEHOST_HOST: edgex-core-data
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_BROKERADDRESS: tcp://MQTT_BROKER_ADDRESS_PLACE_HOLDER:1883
+      WRITABLE_PIPELINE_FUNCTIONS_MQTTSECRETSEND_PARAMETERS_TOPIC: edgex-events
+      WRITABLE_LOGLEVEL: INFO # allows scripts to find and change with sed
+    depends_on:
+      - consul
+      - data
+    read_only: true
+    networks:
+      - edgex-network
+    security_opt:
+      - no-new-privileges:true

--- a/compose-builder/add-device-grove.yml
+++ b/compose-builder/add-device-grove.yml
@@ -27,6 +27,8 @@ services:
     hostname: edgex-device-grove
     networks:
       - edgex-network
+    devices:
+      - /dev/i2c-1
     env_file:
       - common.env
     environment:

--- a/compose-builder/add-modbus-simulator.yml
+++ b/compose-builder/add-modbus-simulator.yml
@@ -1,0 +1,14 @@
+version: '3.7'
+
+services:
+  modbus-simulator:
+    image: nexus3.edgexfoundry.org:10003/edgex-devops/edgex-modbus-simulator${ARCH}:latest
+    container_name: edgex-modbus-simulator
+    hostname: edgex-modbus-simulator
+    ports:
+      - 127.0.0.1:1502:1502/tcp
+    networks:
+      - edgex-network
+    read_only: true
+    security_opt:
+      - no-new-privileges:true

--- a/compose-builder/add-mqtt-broker.yml
+++ b/compose-builder/add-mqtt-broker.yml
@@ -1,0 +1,14 @@
+version: '3.7'
+
+services:
+  mqtt-broker:
+    image: eclipse-mosquitto:${MOSQUITTO_VERSION}
+    ports:
+      - "1883:1883"
+    container_name: edgex-mqtt-broker
+    hostname: edgex-mqtt-broker
+    read_only: true
+    networks:
+      - edgex-network
+    security_opt:
+      - no-new-privileges:true

--- a/compose-builder/add-mqtt-messagebus.yml
+++ b/compose-builder/add-mqtt-messagebus.yml
@@ -19,16 +19,6 @@
 version: '3.7'
 
 services:
-  mqtt-broker:
-    image: eclipse-mosquitto:${MOSQUITTO_VERSION}
-    ports:
-      - "1883:1883"
-    container_name: edgex-mqtt-broker
-    hostname: edgex-mqtt-broker
-    read_only: true
-    networks:
-      - edgex-network
-
   data:
     environment:
       MESSAGEQUEUE_HOST: edgex-mqtt-broker


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/developer-scripts/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Hanoi Compose Builder doesn't have some new options that users requesting
device-grove YML missing `devices` section

## Issue Number: #406


## What is the new behavior?
Added these options:
- mqtt-bus (renamed from mqtt to be more explicit)
- mqtt-broker (new)
- asc-http (new)
- asc-mqtt (new)
- modbus-sim (new)

Aslo added this to device-grove yaml
```
devices:
         - /dev/i2c-1
```


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information